### PR TITLE
fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [LICENSE.md](LICENSE.md)
 
 ## Documentation
 
-See [online documentation](https://Tieske.github.io/terminal.lua/)
+See [online documentation](https://lunarmodules.github.io/terminal.lua/)
 
 ## Changelog & Versioning
 


### PR DESCRIPTION
Description:

This PR fixes a broken link for documentation in README.md that was leading to a 404 error. Since the repository was moved, the old link was no longer valid. The updated link now correctly points to the intended documentation.

Changes made:
Updated the incorrect link in README.md

Testing:
Verified that the new link correctly redirects to the intended page.