### PR TITLE
Fix oldunpack issue in init.lua for Lua 5.1 compatibility

### DIFF
--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -21,7 +21,7 @@ local M = {
 
 local pack, unpack do
   -- nil-safe versions of pack/unpack
-  local oldunpack = unpack or table.unpack -- luacheck: ignore
+  local oldunpack = _G.unpack or table.unpack -- luacheck: ignore
   pack = function(...) return { n = select("#", ...), ... } end
   unpack = function(t, i, j) return oldunpack(t, i or 1, j or t.n or #t) end
 end


### PR DESCRIPTION
Title: Fix oldunpack issue in init.lua for Lua 5.1 compatibility
Description:

This PR fixes an issue where oldunpack wasn’t properly set in init.lua, causing errors in Lua 5.1. The fix ensures _G.oldunpack correctly falls back to _G.unpack or table.unpack, preventing compatibility issues.

Before Changes:
print(oldunpack)
>nil
 
Changes made:

    Updated init.lua to use _G.oldunpack = _G.unpack or table.unpack for Lua 5.1 compatibility.

Testing:

    Verified in Lua 5.1, confirming that the error no longer occurs.