### PR TITLE
Refactor terminal.clear API for better readability

### DIFF
--- a/examples/colors.lua
+++ b/examples/colors.lua
@@ -1,6 +1,6 @@
 -- This example demonstrates the use of the text-attribute stack, and how to
 -- use it to manage text attributes in a more structured way.
-
+package.path = "./src/?.lua;./src/?/init.lua;" .. package.path
 local t = require("terminal")
 
 
@@ -11,7 +11,7 @@ t.initialize{
 }
 
 -- clear the screen, and move cursor to top-left
-t.clear()
+t.clear.screen()
 t.cursor_push(1,1)
 
 -- push text attribues on the stack

--- a/examples/colors.lua
+++ b/examples/colors.lua
@@ -1,6 +1,6 @@
 -- This example demonstrates the use of the text-attribute stack, and how to
 -- use it to manage text attributes in a more structured way.
-package.path = "./src/?.lua;./src/?/init.lua;" .. package.path
+
 local t = require("terminal")
 
 

--- a/spec/03-clear_spec.lua
+++ b/spec/03-clear_spec.lua
@@ -9,32 +9,32 @@ describe("Clear Module Tests", function()
 
 
   it("should return correct ANSI sequence for clearing entire screen", function()
-    assert.are.equal("\27[2J", clear.clears())
+    assert.are.equal("\27[2J", clear.screen_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing line", function()
-    assert.are.equal("\27[2K", clear.clear_lines())
+    assert.are.equal("\27[2K", clear.line_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing line start", function()
-    assert.are.equal("\27[1K", clear.clear_starts())
+    assert.are.equal("\27[1K", clear.start_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing line end", function()
-    assert.are.equal("\27[0K", clear.clear_ends())
+    assert.are.equal("\27[0K", clear.end_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing top of screen", function()
-    assert.are.equal("\27[1J", clear.clear_tops())
+    assert.are.equal("\27[1J", clear.top_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing bottom of screen", function()
-    assert.are.equal("\27[0J", clear.clear_bottoms())
+    assert.are.equal("\27[0J", clear.bottom_seq())
   end)
 
 end)

--- a/spec/03-clear_spec.lua
+++ b/spec/03-clear_spec.lua
@@ -19,12 +19,12 @@ describe("Clear Module Tests", function()
 
 
   it("should return correct ANSI sequence for clearing line start", function()
-    assert.are.equal("\27[1K", clear.start_seq())
+    assert.are.equal("\27[1K", clear.bol_seq())
   end)
 
 
   it("should return correct ANSI sequence for clearing line end", function()
-    assert.are.equal("\27[0K", clear.end_seq())
+    assert.are.equal("\27[0K", clear.eol_seq())
   end)
 
 

--- a/src/terminal/clear.lua
+++ b/src/terminal/clear.lua
@@ -12,79 +12,79 @@ local output = require "terminal.output"
 
 --- Creates an ANSI sequence to clear the entire screen without writing it to the terminal.
 -- @treturn string The ANSI sequence for clearing the entire screen.
-function M.clears()
+function M.screen_seq()
   return "\27[2J"
 end
 
 --- Clears the entire screen by writing the ANSI sequence to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear()
-  output.write(M.clears())
+function M.screen()
+  output.write(M.screen_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear the screen from cursor to top-left without writing.
 -- @treturn string The ANSI sequence for clearing to the top.
-function M.clear_tops()
+function M.top_seq()
   return "\27[1J"
 end
 
 --- Clears the screen from the cursor position to the top-left and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear_top()
-  output.write(M.clear_tops())
+function M.top()
+  output.write(M.top_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear the screen from cursor to bottom-right without writing.
 -- @treturn string The ANSI sequence for clearing to the bottom.
-function M.clear_bottoms()
+function M.bottom_seq()
   return "\27[0J"
 end
 
 --- Clears the screen from the cursor position to the bottom-right and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear_bottom()
-  output.write(M.clear_bottoms())
+function M.bottom()
+  output.write(M.bottom_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear the current line without writing.
 -- @treturn string The ANSI sequence for clearing the entire line.
-function M.clear_lines()
+function M.line_seq()
   return "\27[2K"
 end
 
 --- Clears the current line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear_line()
-  output.write(M.clear_lines())
+function M.line()
+  output.write(M.line_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear from cursor to start of the line without writing.
 -- @treturn string The ANSI sequence for clearing to the start of the line.
-function M.clear_starts()
+function M.start_seq()
   return "\27[1K"
 end
 
 --- Clears from cursor to start of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear_start()
-  output.write(M.clear_starts())
+function M.start()
+  output.write(M.start_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear from cursor to end of the line without writing.
 -- @treturn string The ANSI sequence for clearing to the end of the line.
-function M.clear_ends()
+function M.	end_seq()
   return "\27[0K"
 end
 
 --- Clears from cursor to end of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.clear_end()
-  output.write(M.clear_ends())
+function M.end_()
+  output.write(M.	end_seq())
   return true
 end
 
@@ -92,7 +92,7 @@ end
 -- @tparam number height The height of the box to clear.
 -- @tparam number width The width of the box to clear.
 -- @treturn string The ANSI sequence for clearing the box.
-function M.clear_boxs(height, width)
+function M.box_seq(height, width)
   local line = (" "):rep(width) .. terminal.cursor_lefts(width)
   local line_next = line .. terminal.cursor_downs()
   return line_next:rep(height - 1) .. line .. terminal.cursor_ups(height - 1)
@@ -102,8 +102,8 @@ end
 -- @tparam number height The height of the box to clear.
 -- @tparam number width The width of the box to clear.
 -- @treturn true Always returns true after clearing.
-function M.clear_box(height, width)
-  output.write(M.clear_boxs(height, width))
+function M.box(height, width)
+  output.write(M.box_seq(height, width))
   return true
 end
 

--- a/src/terminal/clear.lua
+++ b/src/terminal/clear.lua
@@ -64,27 +64,27 @@ end
 
 --- Creates an ANSI sequence to clear from cursor to start of the line without writing.
 -- @treturn string The ANSI sequence for clearing to the start of the line.
-function M.start_seq()
+function M.bol_seq()
   return "\27[1K"
 end
 
 --- Clears from cursor to start of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.start()
-  output.write(M.start_seq())
+function M.bol()
+  output.write(M.bol_seq())
   return true
 end
 
 --- Creates an ANSI sequence to clear from cursor to end of the line without writing.
 -- @treturn string The ANSI sequence for clearing to the end of the line.
-function M.	end_seq()
+function M.	eol_seq()
   return "\27[0K"
 end
 
 --- Clears from cursor to end of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.end_()
-  output.write(M.	end_seq())
+function M.eol()
+  output.write(M.	eol_seq())
   return true
 end
 

--- a/src/terminal/clear.lua
+++ b/src/terminal/clear.lua
@@ -83,7 +83,7 @@ end
 
 --- Clears from cursor to end of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.end_()
+function M.end()
   output.write(M.	end_seq())
   return true
 end

--- a/src/terminal/clear.lua
+++ b/src/terminal/clear.lua
@@ -83,7 +83,7 @@ end
 
 --- Clears from cursor to end of the line and writes to the terminal.
 -- @treturn true Always returns true after clearing.
-function M.end()
+function M.end_()
   output.write(M.	end_seq())
   return true
 end


### PR DESCRIPTION
Removes redundancy (terminal.clear.clear() → terminal.clear.screen())
Singular function names for better readability (clear_top() → top())
Consistent suffixes (_seq) to differentiate ANSI sequence functions
solves issue #24 