### PR TITLE
fix(scroll-stack): fix inifinite loop

### DIFF
--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -1384,7 +1384,7 @@ do
       M.shape_pops(math.huge),
       M.visible_pops(math.huge),
       M.textpops(math.huge),
-      scroll.scroll_pops(math.huge),
+      scroll.stack.pops(math.huge),
       M.cursor_sets(r,c) -- restore cursor pos
     )
     t:flush()

--- a/src/terminal/scroll/stack.lua
+++ b/src/terminal/scroll/stack.lua
@@ -52,11 +52,9 @@ end
 -- @treturn string The ANSI sequence representing the new top of the stack.
 -- @within Sequences
 function M.pops(n)
-  n = n or 1
-  for _ = 1, n do
-    if #_scrollstack > 1 then
-      table.remove(_scrollstack) -- Only remove if not at base level
-    end
+  local new_top = math.max(#_scrollstack - (n or 1), 1)
+  for i = new_top + 1, #_scrollstack do
+    _scrollstack[i] = nil
   end
   return M.applys()
 end


### PR DESCRIPTION
if we pass in `math.huge` the loop becomes infinite, but the calculation does not.