### PR TITLE
refactor(query): refactor querying the terminal

### DIFF
--- a/examples/colors.lua
+++ b/examples/colors.lua
@@ -45,11 +45,7 @@ local function main()
   t.output.flush()
   t.input.readansi(5)
 
-  -- restore all settings (reverts to original screen buffer)
-  t.shutdown()
-
-  -- this is printed on the original screen buffer
-  print("done!")
+  return true
 end
 
 
@@ -59,4 +55,6 @@ local opts = {
   displaybackup = true,
   filehandle = io.stdout,
 }
-t.initwrap(opts, main)
+assert(t.initwrap(opts, main))
+
+print("done!")  -- this is printed on the original screen buffer

--- a/src/terminal/width.lua
+++ b/src/terminal/width.lua
@@ -178,7 +178,7 @@ function M.preload(str)
     if #chunk == size or i == #test then
       -- handle the chunk
       t.output.write(table.concat(chunk))
-      local positions, err = t.input.read_cursor_pos(#chunk)
+      local positions, err = t.input.read_query_answer("^\27%[(%d+);(%d+)R$", #chunk)
       if not positions then
         t.textpop() -- restore color (drop hidden)
         return nil, err


### PR DESCRIPTION
It was focussed on reading the cursor position, it is now more generic for any type of query.