### PR TITLE
refactor(sleep): set sleep functions only on main module

### DIFF
--- a/spec/02-input_spec.lua
+++ b/spec/02-input_spec.lua
@@ -52,50 +52,16 @@ describe("input:", function()
 
 
 
-  describe("set_sleep()", function()
-
-    after_each(function()
-      t.input.set_sleep(sys.sleep) -- restore the old function
-    end)
-
-
-    it("sets the default sleep function", function()
-      local called = false
-      local newsleep = function() called = true end
-
-      t.input.set_sleep(newsleep)
-      t.input.readansi(0.01)
-      assert.is_true(called)
-    end)
-
-
-    it("throws an error if the argument is not a function", function()
-      assert.has_error(function()
-        t.input.set_sleep("not a function")
-      end)
-    end)
-
-  end)
-
-
-
-  describe("setbsleep()", function()
-
-    pending("todo", function()
-      -- TODO: implement
-    end)
-
-  end)
-
-
-
   describe("readansi()", function()
 
     it("uses the sleep function set", function()
       local called = false
-      local newsleep = function() called = true end
+      local old_sleep = t._sleep
+      t._sleep = function() called = true end
+      finally(function()
+        t._sleep = old_sleep
+      end)
 
-      t.input.set_sleep(newsleep)
       t.input.readansi(0.01)
       assert.is_true(called)
     end)

--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -41,14 +41,14 @@ M.scroll = require("terminal.scroll")
 M.cursor = require("terminal.cursor")
 -- create locals
 local output = M.output
-local input = M.input
 local clear = M.clear
 local scroll = M.scroll
 local cursor = M.cursor
 
 
-local bsleep  -- a blocking sleep function
-local asleep   -- a (optionally) non-blocking sleep function
+-- Set defaults for sleep functions
+M._bsleep = sys.sleep  -- a blocking sleep function
+M._sleep = sys.sleep   -- a (optionally) non-blocking sleep function
 
 
 
@@ -785,14 +785,11 @@ do
     assert(io.type(filehandle) == 'file', "invalid opts.filehandle")
     output.set_stream(filehandle)
 
-    bsleep = opts.bsleep or sys.sleep
-    assert(type(bsleep) == "function", "invalid opts.bsleep function, expected a function, got " .. type(opts.bsleep))
-    input.set_bsleep(bsleep)
-    output.set_bsleep(bsleep)
+    M._bsleep = opts.bsleep or sys.sleep
+    assert(type(M._bsleep) == "function", "invalid opts.bsleep function, expected a function, got " .. type(opts.bsleep))
 
-    asleep = opts.sleep or sys.sleep
-    assert(type(asleep) == "function", "invalid opts.sleep function, expected a function, got " .. type(opts.sleep))
-    input.set_sleep(asleep)
+    M._asleep = opts.sleep or sys.sleep
+    assert(type(M._asleep) == "function", "invalid opts.sleep function, expected a function, got " .. type(opts.sleep))
 
     termbackup = sys.termbackup()
     if opts.displaybackup then
@@ -843,8 +840,8 @@ do
 
     sys.termrestore(termbackup)
 
-    asleep = nil
-    bsleep = nil
+    M._asleep = sys.sleep
+    M._bsleep = sys.sleep
     termbackup = nil
 
     return true

--- a/src/terminal/output.lua
+++ b/src/terminal/output.lua
@@ -9,14 +9,12 @@
 -- terminal.output.write("hello world")
 -- @module terminal.output
 
-local sys = require "system"
-
 local M = {}
 
+local terminal = require("terminal")
 
 
 local t = io.stderr -- the terminal/stream to operate on
-local bsleep = sys.sleep -- sleep function that blocks
 
 local chunksize = 512 -- chunk size to write in one go
 local bytecount_left = chunksize -- number of bytes to write before flush+sleep required
@@ -29,21 +27,6 @@ local pack do
   local oldunpack = _G.unpack or table.unpack -- luacheck: ignore
   pack = function(...) return { n = select("#", ...), ... } end
   --unpack = function(t, i, j) return oldunpack(t, i or 1, j or t.n or #t) end
-end
-
-
-
---- Set the `sleep` function to use when writing to the terminal.
--- This should be a blocking sleep function, used to throttle the output.
--- A yielding/non-blocking sleep function could potentially cause race-conditions.
--- @tparam function fsleep the sleep function to use.
--- @return true
-function M.set_bsleep(fsleep)
-  if type(fsleep) ~= "function" then
-    error("sleep function must be a function", 2)
-  end
-  bsleep = fsleep
-  return true
 end
 
 
@@ -98,7 +81,7 @@ function M.write(...)
       bytecount_left = chunksize
       t:flush()
       -- sleep a bit to allow the terminal to process the data
-      bsleep(delay) -- blocking because we do not want to yield!
+      terminal._bsleep(delay) -- blocking because we do not want to risk yielding here
     end
   end
 

--- a/src/terminal/output.lua
+++ b/src/terminal/output.lua
@@ -10,7 +10,7 @@
 -- @module terminal.output
 
 local M = {}
-
+package.loaded["terminal.output"] = M -- Register the module early to avoid circular dependencies
 local terminal = require("terminal")
 
 


### PR DESCRIPTION
this simplifies the configuration.

Instead of having the functions in multiple places (input and output) and methods to set them. They ar now only on the main module, set when initializing.