### PR TITLE
fix(indices): range check indices and add tests

### DIFF
--- a/spec/00-utils_spec.lua
+++ b/spec/00-utils_spec.lua
@@ -82,4 +82,25 @@ describe("Utils", function()
 
   end)
 
+
+
+  describe("resolve_index()", function()
+
+    local list = {
+      { i = 3,  max = 5, min = 2,   exp = 3, desc = "proper range remains unchanged" },
+      { i = 0,  max = 5, min = 2,   exp = 2, desc = "zero is clamped to min" },
+      { i = -1, max = 5, min = 2,   exp = 5, desc = "negative index is clamped to max" },
+      { i = -2, max = 5, min = 2,   exp = 4, desc = "negative index is resolved" },
+      { i = -6, max = 5, min = 2,   exp = 2, desc = "negative index is clamped to min" },
+      { i = 0,  max = 5, min = nil, exp = 1, desc = "minimum defaults to 1" },
+    }
+
+    for _, v in ipairs(list) do
+      it(v.desc, function()
+        assert.are.equal(v.exp, utils.resolve_index(v.i, v.max, v.min))
+      end)
+    end
+
+  end)
+
 end)

--- a/spec/04-scroll_spec.lua
+++ b/spec/04-scroll_spec.lua
@@ -1,10 +1,24 @@
 describe("Scroll Module Tests", function()
 
-  local scroll
+  local scroll, old_sys_termsize
 
   setup(function()
+    local sys = require "system"
+    old_sys_termsize = sys.termsize
+    if os.getenv("GITHUB_ACTIONS") then
+      sys.termsize = function()
+        return 25, 80
+      end
+    end
+
     scroll = require "terminal.scroll"
   end)
+
+
+  teardown(function()
+    require("system").termsize = old_sys_termsize
+  end)
+
 
 
 

--- a/spec/05-scroll_stack_spec.lua
+++ b/spec/05-scroll_stack_spec.lua
@@ -1,9 +1,18 @@
 describe("Scroll stack", function()
 
-  local stack, scroll
+  local stack, scroll, old_sys_termsize
 
   before_each(function()
     _G._TEST = true
+
+    local sys = require "system"
+    old_sys_termsize = sys.termsize
+    if os.getenv("GITHUB_ACTIONS") then
+      sys.termsize = function()
+        return 25, 80
+      end
+    end
+
     stack = require "terminal.scroll.stack"
     scroll = require "terminal.scroll"
   end)
@@ -11,6 +20,9 @@ describe("Scroll stack", function()
 
   after_each(function()
     _G._TEST = nil
+
+    require("system").termsize = old_sys_termsize
+
     for mod in pairs(package.loaded) do
       if mod:match("^terminal") then
         package.loaded[mod] = nil

--- a/spec/05-scroll_stack_spec.lua
+++ b/spec/05-scroll_stack_spec.lua
@@ -20,8 +20,8 @@ describe("Scroll stack", function()
 
 
 
-  it("has a reset as the first item on the stack", function()
-    assert.are.same({ scroll.resets() }, stack.__scrollstack)
+  it("has entire screen as the first item on the stack", function()
+    assert.are.same({ {1, -1} }, stack.__scrollstack)
   end)
 
 
@@ -31,7 +31,15 @@ describe("Scroll stack", function()
     it("pushes a new scroll region onto the stack", function()
       local expected = scroll.sets(5, 10)
       local seq = stack.pushs(5, 10)
-      assert.are.same({ scroll.resets(), expected }, stack.__scrollstack)
+      assert.are.same({ { 1, -1 }, { 5, 10 } }, stack.__scrollstack)
+      assert.are.equal(expected, seq)
+    end)
+
+
+    it("pushes a scroll region with negative indexes onto the stack", function()
+      local expected = scroll.sets(-5, -1)
+      local seq = stack.pushs(-5, -1)
+      assert.are.same({ { 1, -1 }, { -5, -1 } }, stack.__scrollstack)
       assert.are.equal(expected, seq)
     end)
 
@@ -42,17 +50,17 @@ describe("Scroll stack", function()
   describe("pops()", function()
 
     it("doesn't pop beyond the last item", function()
-      local expected = scroll.resets()
+      local expected = scroll.sets(1, -1)
       local seq = stack.pops(100)
-      assert.are.same({ expected }, stack.__scrollstack)
+      assert.are.same({ { 1, -1 } }, stack.__scrollstack)
       assert.are.equal(expected, seq)
     end)
 
 
     it("can pop 'math.huge' items", function()
-      local expected = scroll.resets()
+      local expected = scroll.sets(1, -1)
       local seq = stack.pops(math.huge)
-      assert.are.same({ expected }, stack.__scrollstack)
+      assert.are.same({ { 1, -1 } }, stack.__scrollstack)
       assert.are.equal(expected, seq)
     end)
 
@@ -64,7 +72,7 @@ describe("Scroll stack", function()
 
       assert.are.equal(seq2, stack.pops(1))
       assert.are.equal(seq1, stack.pops(1))
-      assert.are.equal(scroll.resets(), stack.pops(1))
+      assert.are.equal(scroll.sets(1, -1), stack.pops(1))
     end)
 
 
@@ -102,7 +110,7 @@ describe("Scroll stack", function()
   describe("applys()", function()
 
     it("returns the current scroll region sequence", function()
-      assert.are.equal(scroll.resets(), stack.applys())
+      assert.are.equal(scroll.sets(1,-1), stack.applys())
       local seq = stack.pushs(5, 10)
       assert.are.equal(seq, stack.applys())
     end)

--- a/spec/06-cursor_spec.lua
+++ b/spec/06-cursor_spec.lua
@@ -1,6 +1,6 @@
 describe("Cursor", function()
 
-  local cursor
+  local cursor, old_sys_termsize
 
   before_each(function()
     for mod in pairs(package.loaded) do
@@ -9,8 +9,22 @@ describe("Cursor", function()
       end
     end
 
+    local sys = require "system"
+    old_sys_termsize = sys.termsize
+    if os.getenv("GITHUB_ACTIONS") then
+      sys.termsize = function()
+        return 25, 80
+      end
+    end
+
     cursor = require "terminal.cursor"
   end)
+
+
+  after_each(function()
+    require("system").termsize = old_sys_termsize
+  end)
+
 
 
 

--- a/spec/06-cursor_spec.lua
+++ b/spec/06-cursor_spec.lua
@@ -214,6 +214,12 @@ describe("Cursor", function()
       assert.are.equal("\27[5;10H", cursor.position.sets(5, 10))
     end)
 
+
+    it("resolves negative indexes to absolute values", function()
+      -- values -5000 shoudl end up being 1
+      assert.are.equal("\27[1;1H", cursor.position.sets(-5000, -5000))
+    end)
+
   end)
 
 

--- a/src/terminal/cursor/position/init.lua
+++ b/src/terminal/cursor/position/init.lua
@@ -54,15 +54,17 @@ end
 
 
 --- Creates ansi sequence to set the cursor position without writing it to the terminal.
--- @tparam number row
--- @tparam number column
+-- @tparam number row the new row. Negative values are resolved from the bottom of the screen,
+-- such that -1 is the last row.
+-- @tparam number column the new column. Negative values are resolved from the right of the screen,
+-- such that -1 is the last column.
 -- @treturn string ansi sequence to write to the terminal
 -- @within Sequences
 function M.sets(row, column)
-  -- Resolve negative indices
+  -- Resolve negative indices, and range check
   local rows, cols = sys.termsize()
-  row = utils.resolve_index(row, rows)
-  column = utils.resolve_index(column, cols)
+  row = utils.resolve_index(row, rows, 1)
+  column = utils.resolve_index(column, cols, 1)
   return "\27[" .. tostring(row) .. ";" .. tostring(column) .. "H"
 end
 
@@ -270,11 +272,14 @@ end
 
 
 --- Creates an ansi sequence to move the cursor to a column on the current row without writing it to the terminal.
--- @tparam number column the column to move to
+-- @tparam number column the column to move to. Negative values are resolved from the right of the screen,
+-- such that -1 is the last column.
 -- @treturn string ansi sequence to write to the terminal
 -- @within Sequences
 function M.columns(column)
-  -- TODO: implement negative indices
+  -- Resolve negative indices, and range check
+  local _, cols = sys.termsize()
+  column = utils.resolve_index(column, cols, 1)
   return "\27["..tostring(column).."G"
 end
 
@@ -291,11 +296,14 @@ end
 
 
 --- Creates an ansi sequence to move the cursor to a row on the current column without writing it to the terminal.
--- @tparam number row the row to move to
+-- @tparam number row the row to move to. Negative values are resolved from the bottom of the screen,
+-- such that -1 is the last row.
 -- @treturn string ansi sequence to write to the terminal
 -- @within Sequences
 function M.rows(row)
-  -- TODO: implement negative indices
+  -- Resolve negative indices, and range check
+  local rows, _ = sys.termsize()
+  row = utils.resolve_index(row, rows, 1)
   return "\27["..tostring(row).."d"
 end
 

--- a/src/terminal/scroll/init.lua
+++ b/src/terminal/scroll/init.lua
@@ -31,15 +31,17 @@ end
 --- Creates an ANSI sequence to set the scroll region without writing to the terminal.
 -- Negative indices are supported, counting from the bottom of the screen.
 -- For example, `-1` refers to the last row, `-2` refers to the second-to-last row, etc.
--- @tparam number start_row The first row of the scroll region (can be negative).
--- @tparam number end_row The last row of the scroll region (can be negative).
+-- @tparam number start_row The first row of the scroll region. Negative values are resolved
+-- from the bottom of the screen, such that `-1` is the last row.
+-- @tparam number end_row The last row of the scroll region. Negative values are resolved
+-- from the bottom of the screen, such that `-1` is the last row.
 -- @treturn string The ANSI sequence for setting the scroll region.
 -- @within Sequences
 function M.sets(start_row, end_row)
   -- Resolve negative indices
   local rows, _ = sys.termsize()
-  start_row = utils.resolve_index(start_row, rows)
-  end_row = utils.resolve_index(end_row, rows)
+  start_row = utils.resolve_index(start_row, rows, 1)
+  end_row = utils.resolve_index(end_row, rows, start_row)
   return "\27[" .. tostring(start_row) .. ";" .. tostring(end_row) .. "r"
 end
 

--- a/src/terminal/scroll/stack.lua
+++ b/src/terminal/scroll/stack.lua
@@ -10,7 +10,7 @@ local scroll = require("terminal.scroll")
 
 
 local _scrollstack = {
-  scroll.resets(), -- Use the function from scroll module
+  { 1, -1 } -- first to last row
 }
 
 
@@ -19,7 +19,8 @@ local _scrollstack = {
 -- @treturn string The ANSI sequence representing the current scroll region.
 -- @within Sequences
 function M.applys()
-  return _scrollstack[#_scrollstack]
+  local entry = _scrollstack[#_scrollstack]
+  return scroll.sets(entry[1], entry[2])
 end
 
 
@@ -39,7 +40,7 @@ end
 -- @treturn string The ANSI sequence representing the pushed scroll region.
 -- @within Sequences
 function M.pushs(top, bottom)
-  _scrollstack[#_scrollstack + 1] = scroll.sets(top, bottom)
+  _scrollstack[#_scrollstack + 1] = { top, bottom }
   return M.applys()
 end
 

--- a/src/terminal/utils.lua
+++ b/src/terminal/utils.lua
@@ -103,13 +103,26 @@ end
 
 
 
---- Resolve negative indices.
+--- Resolve indices.
+-- This function resolves negative indices to positive indices.
+-- The result will be capped into the range [min_value, max_value].
 -- @tparam number index The index to resolve.
 -- @tparam number max_value The maximum value for the index.
-function M.resolve_index(index, max_value)
+-- @tparam[opt=1] number min_value The minimum value for the index.
+function M.resolve_index(index, max_value, min_value)
   if index < 0 then
-    return max_value + index + 1
+    index = max_value + index + 1
   end
+
+  min_value = min_value or 1
+  if index < min_value then
+    index = min_value
+  end
+
+  if index > max_value then
+    index = max_value
+  end
+
   return index
 end
 


### PR DESCRIPTION
fixes #50 

- [x] `terminal.scroll.sets()`
- [x] the `terminal.scroll.stack` should store (and restore) negative indices, instead of hard-coded sequences
- [x] `terminal.cursor.position.sets()`
- [x] `terminal.cursor.position.rows()`
- [x] `terminal.cursor.position.columns()`
- [x] the `terminal.cursor.position.stack` should NOT store negative indices, since it works different from the other stacks
- [x] fix CI for not being able to get terminal size, mock it
