### PR TITLE
feat(width): add function to preload known graphical chars

### DIFF
--- a/src/terminal/draw/init.lua
+++ b/src/terminal/draw/init.lua
@@ -64,6 +64,23 @@ M.box_fmt = utils.make_lookup("box-format", {
 
 
 
+-- returns a string with all box_fmt characters, to pre-load the character width cache
+function M._box_fmt_chars()
+  local r = {}
+  for _, fmt in pairs(M.box_fmt) do
+    if type(fmt) == "table" then
+      for _, v in pairs(fmt) do
+        if type(v) == "string" then
+          r[#r+1] = v
+        end
+      end
+    end
+  end
+  return table.concat(r)
+end
+
+
+
 --- Creates a sequence to draw a box, without writing it to the terminal.
 -- The box is drawn starting from the top-left corner at the current cursor position,
 -- after drawing the cursor will be in the same position.

--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -71,6 +71,18 @@ end
 
 
 
+--- Preload known characters into the width-cache.
+-- Source is the `draw.box` formats, and the `progress` spinner sprites.
+-- Uses `text.width.test` to test the widths of the characters.
+-- @tparam string str additional character string to preload
+-- @return true
+function M.preload_widths(str)
+  text.width.test((str or "") .. M.progress._spinner_fmt_chars() .. M.draw.box_fmt_chars())
+  return true
+end
+
+
+
 do
   local termbackup
   local reset = "\27[0m"

--- a/src/terminal/progress.lua
+++ b/src/terminal/progress.lua
@@ -50,6 +50,19 @@ M.sprites = utils.make_lookup("spinner-sprite", {
 
 
 
+-- returns a string with all spinner characters, to pre-load the character width cache
+function M._spinner_fmt_chars()
+  local r = {}
+  for _, fmt in pairs(M.sprites) do
+    for _, v in pairs(fmt) do
+      r[#r+1] = v
+    end
+  end
+  return table.concat(r)
+end
+
+
+
 --- Create a progress spinner.
 -- The returned spinner function can be called as often as needed to update the spinner. It will only update after
 -- the `stepsize` has passed since the last update. So try to call it at least every `stepsize` seconds, or more often.

--- a/src/terminal/text/width.lua
+++ b/src/terminal/text/width.lua
@@ -9,7 +9,7 @@
 --
 -- This module implements a cache of character widths as they have been measured.
 --
--- To populate the cache with tested widths use `width_test` and `width_test_write`.
+-- To populate the cache with tested widths use `test` and `test_write`.
 --
 -- To check width, using the cached widths, use `utf8cwidth` and `utf8swidth`.
 -- @module terminal.text.width
@@ -72,7 +72,7 @@ end
 -- @treturn[2] nil
 -- @treturn[2] string error message
 -- @within Testing
-function M.width_test(str)
+function M.test(str)
   local size = 50 -- max number of characters to do in 1 terminal write
   local test = {}
   local dup = {}
@@ -147,7 +147,7 @@ end
 -- @tparam string str the string of characters to write and test
 -- @treturn number the width of the string in columns
 -- @within Testing
-function M.width_test_write(str)
+function M.test_write(str)
   local chunk = {} -- every character, pre/post fixed with a query if needed
   local chars = {} -- array chars to test
   local width = 0
@@ -199,7 +199,7 @@ function M.width_test_write(str)
 
   -- re-run to get the total width, since all widths are known now,
   -- but this time do not write the string, just return the width
-  return M.width_test(str)
+  return M.test(str)
 end
 
 


### PR DESCRIPTION
allows to preload spinner utf-8 characters and box-drawing characters into the width cache.

Also renames test function;
- `text.width.width_test_write` -> `text.width.test_write`
- `text.width.width_test` -> `text.width.test`