### PR TITLE
feat(progress): utf8 and double-width awareness for progress.ticker

### DIFF
--- a/examples/progress.lua
+++ b/examples/progress.lua
@@ -38,7 +38,8 @@ local function main()
 
   -- add the ticker one last
   spinners[#spinners+1] = p.spinner {
-    sprites = p.ticker("please wait...", 30, "Done!"),
+    -- uses utf8 character
+    sprites = p.ticker("🕓-Please wait-🎹...", 30, "Done!"),
     col = 1,
     row = r - 1,
     textattr = {fg = "black", bg = "red", brightness = "normal"},

--- a/src/terminal/text/width.lua
+++ b/src/terminal/text/width.lua
@@ -203,5 +203,30 @@ function M.test_write(str)
 end
 
 
+--- Like string:sub(), Returns the substring of the string that starts from i and go until j inclusive, but operators on utf8 characters
+--- Preserves utf8.len()
+-- @tparam string str the string to take the substring of
+-- @tparam number i the starting index of the substring
+-- @tparam number j the ending index of the substring
+-- @treturn string the substring
+function M.utf8sub(str, i, j)
+  local n = utf8.len(str)
+  if #str == n then
+    return str:sub(i, j)
+  end
+  i = i or 1
+  j = j or -1
+  i = ((i - (i >= 0 and 1 or 0)) % n) + 1
+  j = ((j - (j >= 0 and 1 or 0)) % n) + 1
+  if j < i then
+    return ""
+  end
+  local indices = {}
+  for pos, _ in utf8.codes(str) do
+    indices[#indices + 1] = pos
+  end
+  indices[#indices + 1] = #str + 1
+  return str:sub(indices[i], indices[j + 1] - 1)
+end
 
 return M


### PR DESCRIPTION
+ Modified example/progress.lua to demonstrate 

The approach assumes priority of consistent sprites length over inconstent speed

Also, `text_done` is not limited by `text`'s string length