### PR TITLE
feat(size): add terminal.size to reduce system usage

### DIFF
--- a/examples/testscreen.lua
+++ b/examples/testscreen.lua
@@ -1,13 +1,12 @@
 -- This example writes a testscreen (background filled with numbers) and then
 -- writes a box with a message inside.
 
-local sys = require("system")
 local t = require("terminal")
 
 
 -- writes entire screen with numbers 1-9
 local function testscreen()
-  local r, c = sys.termsize()
+  local r, c = t.size()
   local row = ("1234567890"):rep(math.floor(c/10) + 1):sub(1, c)
 
   -- push a color on the stack
@@ -41,7 +40,7 @@ testscreen()
 
 -- draw a box, with 2 cols/rows margin around the screen
 local edge = 2
-local r,c = sys.termsize()
+local r,c = t.size()
 t.cursor.position.set(edge+1, edge+1)
 t.draw.box(r - 2*edge, c - 2*edge, t.draw.box_fmt.double, true, "test screen")
 

--- a/src/terminal/cursor/position/init.lua
+++ b/src/terminal/cursor/position/init.lua
@@ -6,10 +6,10 @@ local M = {}
 package.loaded["terminal.cursor.position"] = M -- Register the module early to avoid circular dependencies
 M.stack = require "terminal.cursor.position.stack"
 
+local terminal = require("terminal")
 local output = require("terminal.output")
 local input = require("terminal.input")
 local utils = require("terminal.utils")
-local sys = require("system")
 
 
 
@@ -62,7 +62,7 @@ end
 -- @within Sequences
 function M.set_seq(row, column)
   -- Resolve negative indices, and range check
-  local rows, cols = sys.termsize()
+  local rows, cols = terminal.size()
   row = utils.resolve_index(row, rows, 1)
   column = utils.resolve_index(column, cols, 1)
   return "\27[" .. tostring(row) .. ";" .. tostring(column) .. "H"
@@ -278,7 +278,7 @@ end
 -- @within Sequences
 function M.column_seq(column)
   -- Resolve negative indices, and range check
-  local _, cols = sys.termsize()
+  local _, cols = terminal.size()
   column = utils.resolve_index(column, cols, 1)
   return "\27["..tostring(column).."G"
 end
@@ -302,7 +302,7 @@ end
 -- @within Sequences
 function M.row_seq(row)
   -- Resolve negative indices, and range check
-  local rows, _ = sys.termsize()
+  local rows, _ = terminal.size()
   row = utils.resolve_index(row, rows, 1)
   return "\27["..tostring(row).."d"
 end

--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -54,6 +54,17 @@ M._sleep = sys.sleep   -- a (optionally) non-blocking sleep function
 
 
 
+--- Returns the terminal size in rows and columns.
+-- Just a convenience, maps 1-on-1 to `system.termsize`.
+-- @treturn[1] number number of rows
+-- @treturn[1] number number of columns
+-- @treturn[2] nil on error
+-- @treturn[2] string error message
+-- @function size
+M.size = sys.termsize
+
+
+
 --- Returns a string sequence to make the terminal beep.
 -- @treturn string ansi sequence to write to the terminal
 function M.beep_seq()

--- a/src/terminal/scroll/init.lua
+++ b/src/terminal/scroll/init.lua
@@ -4,7 +4,7 @@
 local M = {}
 package.loaded["terminal.scroll"] = M -- Register the module early to avoid circular dependencies
 
-local sys = require "system"
+local terminal = require("terminal")
 local output = require("terminal.output")
 local utils = require("terminal.utils")
 
@@ -39,7 +39,7 @@ end
 -- @within Sequences
 function M.set_seq(start_row, end_row)
   -- Resolve negative indices
-  local rows, _ = sys.termsize()
+  local rows, _ = terminal.size()
   start_row = utils.resolve_index(start_row, rows, 1)
   end_row = utils.resolve_index(end_row, rows, start_row)
   return "\27[" .. tostring(start_row) .. ";" .. tostring(end_row) .. "r"

--- a/src/terminal/text/width.lua
+++ b/src/terminal/text/width.lua
@@ -121,7 +121,7 @@ function M.test(str)
         local w = pos[2] - c
         if w < 0 then
           -- cursor wrapped to next line
-          local _, cols = t.termsize()
+          local _, cols = t.size()
           w = w + cols
         end
         char_widths[chars[j]] = w
@@ -191,7 +191,7 @@ function M.test_write(str)
     local w = col_end - col_start
     if w < 0 then
       -- cursor wrapped to next line
-      local _, cols = t.termsize()
+      local _, cols = t.size()
       w = w + cols
     end
     char_widths[char] = w


### PR DESCRIPTION
by passing through this function, a client application can probably forego on luasystem all together. Will be used under the hood, but the client app won't have to interact with it directly.