### PR TITLE
docs(example) add interactive menu example

### DIFF
--- a/examples/menu.lua
+++ b/examples/menu.lua
@@ -1,5 +1,5 @@
 local t = require "terminal"
---local Sequence = require("terminal.sequence")
+local Sequence = require("terminal.sequence")
 
 -- Key bindings for arrow keys, 'j', 'k', and Enter.
 local key_names = {
@@ -62,22 +62,20 @@ function IMenu:handleInput()
     local idx = 1                                    -- Index of the currently highlighted option.
     t.cursor.position.up(max+1)                         -- Offset cursor for initial display.
     self:select(self._choices[1])                   -- Highlight the first option.
-    t.cursor.position.up(1)                         -- Offset cursor for initial display.
+    --t.cursor.position.up(1)                         -- Offset cursor for initial display.
     while true do
         local  _, keyName = self:readKey()
 
         if keyName == "up" and idx > min then
             self:unselect(self._choices[idx])
-            t.cursor.position.up(2)                     -- Move cursor up.
-            idx = idx - 1                                -- Decrement option index.
+            t.cursor.position.up(1)
+            idx = idx - 1
             self:select(self._choices[idx])
-            t.cursor.position.up(1)                     -- Move cursor up.
         elseif keyName == "down" and idx < max then
             self:unselect(self._choices[idx])
-            --t.cursor.position.down(1)                   -- Move cursor down.
-            idx = idx + 1                                -- Increment option index.
+            t.cursor.position.down(1)
+            idx = idx + 1
             self:select(self._choices[idx])
-            t.cursor.position.up(1)                   -- Move cursor down.
         elseif keyName == "enter" then
             self.selected = idx                            -- Set the selected option index.
             t.cursor.position.down(max - idx+1)             -- Move cursor past the options.
@@ -89,18 +87,23 @@ end
 -- Displays an unselected option.
 -- @param string : the option name you want to unselect
 function IMenu:unselect(opt)
-    t.text.stack.push{ -- Dim the text color.
+    t.output.write(Sequence(function() return t.text.stack.push_seq{ -- Dim the text color.
         fg = "white",
         brightness = "dim",
-    }
-    t.output.write(pipe, "    ", circle, " ", opt, "\n")
-    t.text.stack.pop() -- Restore text color.
+    }end,
+    pipe, "    ", circle, " ", opt, "\n",
+    t.text.stack.pop_seq, -- Restore text color.
+    t.cursor.position.up_seq(1)))
+
 end
 
 -- Displays a selected option.
 -- @param string : the option name you want to select
 function IMenu:select(opt)
-    t.output.write(pipe, "    ", dot, " ", opt, "\n")
+    t.output.write(Sequence(
+    pipe, "    ", dot, " ", opt, "\n",
+    t.cursor.position.up_seq(1)
+    ))
 end
 
 -- Runs the prompt and returns the selected option index.

--- a/examples/menu.lua
+++ b/examples/menu.lua
@@ -1,0 +1,144 @@
+local t = require "terminal"
+local Sequence = require("terminal.sequence")
+
+
+-- Key bindings for arrow keys, 'j', 'k', and Enter.
+local key_names = {
+  ["\27[A"] = "up", -- Up arrow key
+  ["k"] = "up",     -- 'k' key
+  ["\27[B"] = "down", -- Down arrow key
+  ["j"] = "down",   -- 'j' key
+  ["\r"] = "enter",  -- Carriage return (Enter)
+  ["\n"] = "enter",  -- Newline (Enter)
+}
+
+local greenDiamond = Sequence(
+  function() return t.text.stack.push_seq({ fg = "green" }) end, -- set green FG color AT TIME OF WRITING
+  "◇", -- write a diamond
+  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
+)
+local pipe= Sequence(
+  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
+  "│", -- write a pipe
+  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
+)
+
+local circle= Sequence(
+  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
+  "○", -- write a circle
+  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
+)
+
+local dot= Sequence(
+  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
+  "●", -- write a dot
+  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
+)
+
+local IMenu = {}
+
+-- Initialize choices, cursor position, and selected option.
+IMenu._choices = {} -- Array of selectable options (strings).
+IMenu._choices = {}
+IMenu.cursorX = 0
+IMenu.cursorY = 0
+IMenu.selected = nil -- The option the user selects
+
+function IMenu:choices(chs)
+  -- choices may only be strings
+  for _, val in pairs(chs) do
+    if type(val) ~= "string" then
+      return nil, "expected choices to be string but got"..type(val).." instead"
+    end
+  end
+
+  self._choices = chs
+  return true, nil
+end
+
+
+function IMenu:readKey()
+  local key = t.input.readansi(1)
+  return key, key_names[key] or key
+end
+function IMenu:updateCursor(y, x)
+  self.cursorY = y
+  self.cursorX = x
+  t.cursor.position.set(y, x)
+end
+
+
+
+function IMenu:handleInput()
+  if #self._choices == 0 then
+    return nil, "_choices empty"
+  end
+
+  self.cursorY = self.cursorY + 2                   -- Offset cursor for initial display.
+  local max = self.cursorY                          -- Top boundary of selectable options.
+  local min = self.cursorY + #self._choices - 1     -- Bottom boundary.
+  t.cursor.position.set(self.cursorY, self.cursorX)
+  local idx = 1                                     -- Index of the currently highlighted option.
+  self:select(self._choices[idx])                   -- Highlight the first option.
+  while true do
+    self:updateCursor(self.cursorY, self.cursorX) -- Update cursor position.
+    local _, keyName = self:readKey()
+
+    if keyName == "up" and self.cursorY > max then
+      self:unselect(self._choices[idx])      -- Unhighlight current option.
+      self:updateCursor(self.cursorY - 1, 1) -- Move cursor up.
+      idx = idx - 1                          -- Decrement option index.
+      self:select(self._choices[idx])        -- Highlight new option.
+    elseif keyName == "down" and self.cursorY < min then
+      self:unselect(self._choices[idx])      -- Unhighlight current option.
+      self:updateCursor(self.cursorY + 1, 1) -- Move cursor down.
+      idx = idx + 1                          -- Increment option index.
+      self:select(self._choices[idx])        -- Highlight new option.
+    elseif keyName == "enter" then
+      self.selected = idx                    -- Set the selected option index.
+      self:updateCursor(min + 1, self.cursorX) -- Move cursor past the options.
+      return self.selected                   -- Return the selected index.
+    end
+  end
+end
+
+
+-- Displays an unselected option.
+-- @param string : the option name you want to unselect
+function IMenu:unselect(opt)
+  t.text.stack.push{ -- Dim the text color.
+    fg = "white",
+    brightness = "dim",
+  }
+  t.output.write(pipe, "    ", circle, " ", opt, "\n")
+  t.text.stack.pop() -- Restore text color.
+end
+
+-- Displays a selected option.
+-- @param string : the option name you want to select
+function IMenu:select(opt)
+  t.output.write(pipe, "    ", dot, " ", opt, "\n")
+end
+
+-- Runs the prompt and returns the selected option index.
+function IMenu:run()
+  t.initialize()
+  t.cursor.visible.set(false)           -- Hide the cursor.
+  local r, c = t.cursor.position.get()  -- Get current cursor position.
+  IMenu:updateCursor(r + 1, c)       -- Position cursor for prompt.
+  t.output.write(pipe, "\n")
+  t.output.write(greenDiamond, "  ", "Select option:", "\n") -- Display prompt message.
+  for _, val in pairs(self._choices) do
+    self:unselect(val)        -- Display each option initially unselected.
+  end
+  self:handleInput()          -- Handle user input.
+  t.output.write("\n")
+  t.cursor.visible.set(true)  -- Restore cursor visibility.
+  t.shutdown()
+  return self.selected        -- Return selected option index.
+end
+
+IMenu:choices({"Typescript", "Typescript + swc","Javascript", "Javascript + swc"})
+print("selected: "..IMenu._choices[IMenu:run()])
+
+return IMenu

--- a/examples/menu.lua
+++ b/examples/menu.lua
@@ -78,11 +78,11 @@ local function _readKey()
 end
 
 local function _handleInput()
-    if M.choices == 0 then
+    if #M.choices == 0 then
         return nil, "choices empty"
     end
 
-    local max = M.choices
+    local max = #M.choices
     local min = 1
     local idx = 1                                    -- Index of the currently highlighted option.
     t.cursor.position.up(max+1)                         -- Offset cursor for initial display.

--- a/examples/menu.lua
+++ b/examples/menu.lua
@@ -1,144 +1,121 @@
 local t = require "terminal"
-local Sequence = require("terminal.sequence")
-
+--local Sequence = require("terminal.sequence")
 
 -- Key bindings for arrow keys, 'j', 'k', and Enter.
 local key_names = {
-  ["\27[A"] = "up", -- Up arrow key
-  ["k"] = "up",     -- 'k' key
-  ["\27[B"] = "down", -- Down arrow key
-  ["j"] = "down",   -- 'j' key
+  ["\27[A"] = "up",  -- Up arrow key
+  ["k"] = "up",      -- 'k' key
+  ["\27[B"] = "down",-- Down arrow key
+  ["j"] = "down",    -- 'j' key
   ["\r"] = "enter",  -- Carriage return (Enter)
   ["\n"] = "enter",  -- Newline (Enter)
 }
 
-local greenDiamond = Sequence(
-  function() return t.text.stack.push_seq({ fg = "green" }) end, -- set green FG color AT TIME OF WRITING
-  "◇", -- write a diamond
-  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
-)
-local pipe= Sequence(
-  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
-  "│", -- write a pipe
-  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
-)
-
-local circle= Sequence(
-  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
-  "○", -- write a circle
-  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
-)
-
-local dot= Sequence(
-  function() return t.text.stack.push_seq({ fg = "white" }) end, -- set green FG color AT TIME OF WRITING
-  "●", -- write a dot
-  t.text.stack.pop_seq -- passing in function is enough, since no parameters needed
-)
+local greenDiamond = "◇"
+local pipe         = "│"
+local circle       = "○"
+local dot          = "●"
 
 local IMenu = {}
 
 -- Initialize choices, cursor position, and selected option.
 IMenu._choices = {} -- Array of selectable options (strings).
-IMenu._choices = {}
-IMenu.cursorX = 0
-IMenu.cursorY = 0
 IMenu.selected = nil -- The option the user selects
 
-function IMenu:choices(chs)
-  -- choices may only be strings
-  for _, val in pairs(chs) do
-    if type(val) ~= "string" then
-      return nil, "expected choices to be string but got"..type(val).." instead"
+function IMenu:__template()
+    local menu = greenDiamond .. "  Select an option:\n"
+    for _, option in pairs(self._choices) do
+        menu = menu .. pipe .. "    " .. circle .. " " .. option .. "\n"
     end
-  end
-
-  self._choices = chs
-  return true, nil
+    t.text.stack.push{ -- Dim the text color.
+        fg = "white",
+        brightness = "dim",
+    }
+    print(menu)
+    t.text.stack.pop()
 end
 
+function IMenu:choices(chs)
+    -- choices may only be strings
+    for _, val in pairs(chs) do
+        if type(val) ~= "string" then
+            return nil, "expected choices to be string but got" .. type(val) .. " instead"
+        end
+    end
+
+    self._choices = chs
+    return true, nil
+end
 
 function IMenu:readKey()
-  local key = t.input.readansi(1)
-  return key, key_names[key] or key
+    local key = t.input.readansi(1)
+    return key, key_names[key] or key
 end
-function IMenu:updateCursor(y, x)
-  self.cursorY = y
-  self.cursorX = x
-  t.cursor.position.set(y, x)
-end
-
-
 
 function IMenu:handleInput()
-  if #self._choices == 0 then
-    return nil, "_choices empty"
-  end
-
-  self.cursorY = self.cursorY + 2                   -- Offset cursor for initial display.
-  local max = self.cursorY                          -- Top boundary of selectable options.
-  local min = self.cursorY + #self._choices - 1     -- Bottom boundary.
-  t.cursor.position.set(self.cursorY, self.cursorX)
-  local idx = 1                                     -- Index of the currently highlighted option.
-  self:select(self._choices[idx])                   -- Highlight the first option.
-  while true do
-    self:updateCursor(self.cursorY, self.cursorX) -- Update cursor position.
-    local _, keyName = self:readKey()
-
-    if keyName == "up" and self.cursorY > max then
-      self:unselect(self._choices[idx])      -- Unhighlight current option.
-      self:updateCursor(self.cursorY - 1, 1) -- Move cursor up.
-      idx = idx - 1                          -- Decrement option index.
-      self:select(self._choices[idx])        -- Highlight new option.
-    elseif keyName == "down" and self.cursorY < min then
-      self:unselect(self._choices[idx])      -- Unhighlight current option.
-      self:updateCursor(self.cursorY + 1, 1) -- Move cursor down.
-      idx = idx + 1                          -- Increment option index.
-      self:select(self._choices[idx])        -- Highlight new option.
-    elseif keyName == "enter" then
-      self.selected = idx                    -- Set the selected option index.
-      self:updateCursor(min + 1, self.cursorX) -- Move cursor past the options.
-      return self.selected                   -- Return the selected index.
+    if #self._choices == 0 then
+        return nil, "_choices empty"
     end
-  end
-end
 
+    local max = #self._choices
+    local min = 1
+    local idx = 1                                    -- Index of the currently highlighted option.
+    t.cursor.position.up(max+1)                         -- Offset cursor for initial display.
+    self:select(self._choices[1])                   -- Highlight the first option.
+    t.cursor.position.up(1)                         -- Offset cursor for initial display.
+    while true do
+        local  _, keyName = self:readKey()
+
+        if keyName == "up" and idx > min then
+            self:unselect(self._choices[idx])
+            t.cursor.position.up(2)                     -- Move cursor up.
+            idx = idx - 1                                -- Decrement option index.
+            self:select(self._choices[idx])
+            t.cursor.position.up(1)                     -- Move cursor up.
+        elseif keyName == "down" and idx < max then
+            self:unselect(self._choices[idx])
+            --t.cursor.position.down(1)                   -- Move cursor down.
+            idx = idx + 1                                -- Increment option index.
+            self:select(self._choices[idx])
+            t.cursor.position.up(1)                   -- Move cursor down.
+        elseif keyName == "enter" then
+            self.selected = idx                            -- Set the selected option index.
+            t.cursor.position.down(max - idx+1)             -- Move cursor past the options.
+            return self.selected                            -- Return the selected index.
+        end
+    end
+end
 
 -- Displays an unselected option.
 -- @param string : the option name you want to unselect
 function IMenu:unselect(opt)
-  t.text.stack.push{ -- Dim the text color.
-    fg = "white",
-    brightness = "dim",
-  }
-  t.output.write(pipe, "    ", circle, " ", opt, "\n")
-  t.text.stack.pop() -- Restore text color.
+    t.text.stack.push{ -- Dim the text color.
+        fg = "white",
+        brightness = "dim",
+    }
+    t.output.write(pipe, "    ", circle, " ", opt, "\n")
+    t.text.stack.pop() -- Restore text color.
 end
 
 -- Displays a selected option.
 -- @param string : the option name you want to select
 function IMenu:select(opt)
-  t.output.write(pipe, "    ", dot, " ", opt, "\n")
+    t.output.write(pipe, "    ", dot, " ", opt, "\n")
 end
 
 -- Runs the prompt and returns the selected option index.
 function IMenu:run()
-  t.initialize()
-  t.cursor.visible.set(false)           -- Hide the cursor.
-  local r, c = t.cursor.position.get()  -- Get current cursor position.
-  IMenu:updateCursor(r + 1, c)       -- Position cursor for prompt.
-  t.output.write(pipe, "\n")
-  t.output.write(greenDiamond, "  ", "Select option:", "\n") -- Display prompt message.
-  for _, val in pairs(self._choices) do
-    self:unselect(val)        -- Display each option initially unselected.
-  end
-  self:handleInput()          -- Handle user input.
-  t.output.write("\n")
-  t.cursor.visible.set(true)  -- Restore cursor visibility.
-  t.shutdown()
-  return self.selected        -- Return selected option index.
+    t.initialize()
+    t.cursor.visible.set(false)                     -- Hide the cursor.
+    self:__template()
+    self:handleInput()                               -- Handle user input.
+    t.output.write("\n")
+    t.cursor.visible.set(true)                       -- Restore cursor visibility.
+    t.shutdown()
+    return self.selected                              -- Return selected option index.
 end
 
-IMenu:choices({"Typescript", "Typescript + swc","Javascript", "Javascript + swc"})
+IMenu:choices({"Typescript", "Typescript + swc", "Javascript", "Javascript + swc"})
 print("selected: "..IMenu._choices[IMenu:run()])
 
 return IMenu


### PR DESCRIPTION

This commit adds a new example, IMenu, that demonstrates how to create an interactive IMenu in the terminal using arrow keys, 'j'/'k', and Enter for selection.

The example allows users to add choices, navigate with up/down keys, and select an option. It utilizes ANSI sequences for cursor control and visual feedback.

This example will help users learn how to create interactive command line tools using the terminal library.