### PR TITLE
fix(input): proper sleep method is now used

### DIFF
--- a/examples/async.lua
+++ b/examples/async.lua
@@ -1,0 +1,55 @@
+-- An example of asynchoneous input and output using the `copas` library.
+-- This example shows how to use the `copas` library to create a simple
+-- terminal application that displays the current time and waits for keyboard input.
+
+local copas = require("copas")
+local t = require("terminal")
+
+
+
+-- add timer display thread
+copas.addthread(function()
+
+  local function updatetime(time)
+    local dt = os.date(" %H:%M:%S ", time)
+    t.output.write(
+      t.cursor.position.stack.push_seq(1, - #dt),
+      t.text.stack.push_seq{ fg = "black", bg = "white" },
+      dt,
+      t.text.stack.pop_seq(),
+      t.cursor.position.stack.pop_seq()
+    )
+  end
+
+  while not copas.exiting() do
+    local t = copas.gettime()
+    updatetime(math.floor(t))
+    copas.pause(1 - (t - math.floor(t))) -- sleep until the next second
+  end
+end)
+
+
+
+-- add thread waiting for keyboard input
+copas.addthread(function()
+  t.output.print("Press 'q' to exit...")
+
+  while not copas.exiting() do
+    local key = t.input.readansi(math.huge)
+    if key then
+      t.output.print("You pressed: " .. key:gsub("\027", "\\027"))
+      if key == "q" then
+        copas.exit()
+      end
+    end
+  end
+end)
+
+
+
+-- start the copas loop, wrapped in term setup/teardown
+t.initwrap({
+  displaybackup = true,
+  filehandle = io.stdout,
+  sleep = copas.pause, -- ensure readansi is yielding
+}, copas.loop)

--- a/spec/02-input_spec.lua
+++ b/spec/02-input_spec.lua
@@ -57,9 +57,9 @@ describe("input:", function()
     it("uses the sleep function set", function()
       local called = false
       local old_sleep = t._sleep
-      t._sleep = function() called = true end
+      t._asleep = function() called = true end
       finally(function()
-        t._sleep = old_sleep
+        t._asleep = old_sleep
       end)
 
       t.input.readansi(0.01)

--- a/src/terminal/input.lua
+++ b/src/terminal/input.lua
@@ -54,7 +54,7 @@ M.sys_readansi = sys.readansi
 function M.readansi(timeout, fsleep)
   if kbend == 0 then
     -- buffer is empty, so read from the terminal
-    return M.sys_readansi(timeout, fsleep or terminal._sleep)
+    return M.sys_readansi(timeout, fsleep or terminal._asleep)
   end
 
   -- return buffered input


### PR DESCRIPTION
Due to typo sys.sleep was still used.