### PR TITLE
Refactor: extract ProgressSpinner class with minimal OOP support

### DIFF
--- a/examples/progress_spinner.lua
+++ b/examples/progress_spinner.lua
@@ -1,0 +1,35 @@
+local t = require("terminal")
+local progress= require("terminal.progress")
+
+local ProgressSpinner = progress.ProgressSpinner
+local sprites = progress.sprites
+
+local function main()
+  local r, _ = t.cursor.position.get()
+  local spinner = ProgressSpinner:new{
+    sprites = sprites.spinner,
+    col = 1,
+    row = r - 2,
+    stepsize = 0.1,
+    textattr = {fg = "blue", brightness = "normal"},
+    done_sprite = "✔ ",
+    done_textattr = {fg = "green", brightness = "bright"},
+  }
+
+  t.output.write("Press any key to stop the spinner...\n")
+  t.cursor.visible.set(false)
+
+  -- Spinner loop
+  while true do
+    spinner:step_once()
+    t.output.flush()
+    if t.input.readansi(0.02) then break end
+  end
+
+  -- Mark done
+  spinner:step_once(true)
+  t.cursor.visible.set(true)
+  t.output.write("\n")
+end
+
+t.initwrap(main)()

--- a/spec/09-progress_spinner_spec.lua
+++ b/spec/09-progress_spinner_spec.lua
@@ -1,0 +1,36 @@
+local t = require("terminal")
+local progress = require("terminal.progress")
+local ProgressSpinner = progress.ProgressSpinner
+
+describe("ProgressSpinner", function()
+  it("initializes with valid options", function()
+    local spinner = ProgressSpinner:new{
+      sprites = progress.sprites.spinner,
+      stepsize = 0.1,
+      textattr = {fg = "blue"},
+      done_textattr = {fg = "green"},
+      done_sprite = "✔ ",
+      row = 5,
+      col = 1,
+    }
+    assert.is_table(spinner)
+    assert.are.equal(type(spinner.step_once), "function")
+  end)
+
+  it("throws error without sprites", function()
+    assert.has_error(function()
+      ProgressSpinner:new{}
+    end, "sprites must be provided")
+  end)
+
+  it("rotates sprite steps", function()
+    local spinner = ProgressSpinner:new{
+      sprites = { [0] = "-", "|", "/", "\\" },
+      stepsize = 0,
+    }
+    for _ = 1, 5 do
+      spinner:step_once()
+    end
+    spinner:step_once(true) -- done state
+  end)
+end)

--- a/spec/09-progress_spinner_spec.lua
+++ b/spec/09-progress_spinner_spec.lua
@@ -1,4 +1,3 @@
-local t = require("terminal")
 local progress = require("terminal.progress")
 local ProgressSpinner = progress.ProgressSpinner
 

--- a/src/terminal/progress.lua
+++ b/src/terminal/progress.lua
@@ -81,7 +81,7 @@ function ProgressSpinner:new(opts)
     "both row and col must be provided, or neither")
 
   self.steps = {}
-  local setpos = (self.row and t.cursor.position.set_seq(self.row, self.col)) or ""
+  local setpos = (self.row and self.col) and t.cursor.position.set_seq(self.row, self.col) or ""
   local savepos = (self.row and t.cursor.position.backup_seq()) or ""
   local restorepos = (self.row and t.cursor.position.restore_seq()) or ""
 

--- a/src/terminal/progress.lua
+++ b/src/terminal/progress.lua
@@ -1,6 +1,6 @@
 --- A module for progress updating.
 -- @module terminal.progress
-
+local utf8 = require("utf8")
 local M = {}
 package.loaded["terminal.progress"] = M -- Register the module early to avoid circular dependencies
 
@@ -97,12 +97,11 @@ function ProgressSpinner:new(opts)
     s[#s+1] = savepos
     s[#s+1] = setpos
     s[#s+1] = (i == 0 and attr_push_done) or attr_push
-    s[#s+1] = sprite .. t.cursor.position.left_seq(tw.utf8swidth(sprite))
+    s[#s+1] = sprite .. t.cursor.position.left_seq(tw.utf8swidth(sprite, utf8))
     s[#s+1] = attr_pop
     s[#s+1] = restorepos
-    self.steps[i] = s
+    self.steps[i == 0 and (#self.sprites + 1) or i] = s
   end
-
   return self
 end
 
@@ -111,7 +110,7 @@ end
 function ProgressSpinner:step_once(done)
   if gettime() >= self.next_step or done then
     if done then
-      self.step = 0
+      self.step = #self.sprites + 1
     else
       self.next_step = gettime() + self.stepsize
       self.step = self.step + 1

--- a/src/terminal/util/class.lua
+++ b/src/terminal/util/class.lua
@@ -1,0 +1,20 @@
+-- src/terminal/util/class.lua
+return function(base)
+  local c = {}
+  if base then
+    setmetatable(c, { __index = base })
+    c.__base = base
+  end
+
+  c.__index = c
+
+  function c:new(...)
+    local instance = setmetatable({}, self)
+    if instance.init then
+      instance:init(...)
+    end
+    return instance
+  end
+
+  return c
+end


### PR DESCRIPTION
This PR introduces a refactor of the existing spinner logic in terminal.progress, by extracting it into a dedicated ProgressSpinner class. This follows the new minimal object-oriented model using util/class.lua.

Changes

- Added ProgressSpinner class to terminal.progress with:
- Encapsulated spinner rendering logic
- Configurable animation frames, position, and text styling
- :step_once(done) method for clean updates
- Added example: examples/progress_spinner.lua
- Added src/terminal/util/class.lua – a lightweight metatable-based OOP helper
- Retained compatibility with existing spinner-based demos