### PR TITLE
refactor(class): remove lookup chain, remove self

### DIFF
--- a/spec/00-utils_spec.lua
+++ b/spec/00-utils_spec.lua
@@ -122,6 +122,7 @@ describe("Utils", function()
       end
       local instance = MyClass()
       assert.is_not_nil(instance)
+      assert.are.equal(instance.super, MyClass)
       assert.are.equal(42, instance.value)
     end)
 
@@ -140,26 +141,26 @@ describe("Utils", function()
 
       local instance = Lion()
       assert.is_not_nil(instance)
+      assert.are.equal(Lion.super, Cat)
       assert.are.equal(84, instance.value)
     end)
 
 
-    it("instantiating uses the table passed in", function()
+    it("instantiating calls initializer with parameters", function()
       local Cat = utils.class()
-      function Cat:init()
-        self.value = self.value or 42
+      function Cat:init(value)
+        self.value = value or 42
       end
 
       local Lion = utils.class(Cat)
-      function Lion:init()
-        Cat.init(self)  -- call ancenstor initializer
+      function Lion:init(...)
+        Cat.init(self, ...)  -- call ancenstor initializer
         self.value = self.value * 2
       end
 
-      local table_in = { value = 10 }
-      local instance = Lion(table_in)
+      local instance = Lion(10)
       assert.is_not_nil(instance)
-      assert.equal(table_in, instance)
+      assert.are.equal(instance.super, Lion)
       assert.are.equal(20, instance.value)
     end)
 

--- a/src/terminal/utils.lua
+++ b/src/terminal/utils.lua
@@ -129,15 +129,48 @@ end
 
 
 do
-  local constructor = function(cls, instance)
-    assert(rawget(cls, "__index"), "Constructor can only be called on a Class")
-    instance = instance or {}
-    setmetatable(instance, cls)
-    if instance.init then
-      instance:init()
+  -- copy class methods and properties into an instance table.
+  -- traverses up the chain to copy all methods and properties of ancestors as well.
+  local function copy_class_methods(cls)
+    local instance = {}
+    while cls do
+      for k, v in pairs(cls) do
+        if not rawget(instance, k) then
+          instance[k] = v
+        end
+      end
+
+      cls = cls.super
     end
+
     return instance
   end
+
+
+
+  -- upon instantiation, create a 'fat' instance, copying all class + ancestor methods
+  -- into the instance, so that they can be called without the class lookup chain.
+  local function constructor(cls, ...)
+    assert(rawget(cls, "__index"), "Constructor can only be called on a Class")
+
+    -- populate the instance
+    local instance = copy_class_methods(cls)
+
+    -- clear unused entries, used only for classes
+    instance.__call = nil
+    instance.__index = nil
+
+    instance.super = cls
+    setmetatable(instance, cls)
+
+    if instance.init then
+      instance.init = nil
+      cls.init(instance, ...)
+    end
+
+    return instance
+  end
+
 
 
   local base = {}
@@ -153,19 +186,20 @@ do
   -- @treturn table The new class.
   -- @usage
   -- local Cat = utils.class()
-  -- function Cat:init()
-  --   self.value = self.value or 42
+  -- function Cat:init(value)
+  --   self.value = value or 42
   -- end
   --
   -- local Lion = utils.class(Cat)
-  -- function Lion:init()
-  --   Cat.init(self)        -- call ancestor initializer
+  -- function Lion:init(value)
+  --   assert(self.super == Cat, "Superclass is not a Cat")
+  --   Cat.init(self, value)   -- call ancestor initializer
   --   self.value = self.value * 2
   -- end
   --
   -- local instance1 = Lion()
   -- print(instance1.value)      --> 84
-  -- local instance2 = Lion({ value = 10 })
+  -- local instance2 = Lion(10)
   -- print(instance2.value)      --> 20
   function M.class(baseclass)
     baseclass = baseclass or base
@@ -173,6 +207,7 @@ do
     local class = setmetatable({}, baseclass)
     class.__index = class
     class.__call = constructor
+    class.super = baseclass
 
     return setmetatable(class, baseclass)
   end


### PR DESCRIPTION
ancestor methods/props are copied now for performance, to remove
the lookup chain.
upon instantiating, self is no longer passed in, but an options
table.