### PR TITLE
Cow example and cursor position stack

### DIFF
--- a/examples/cow.lua
+++ b/examples/cow.lua
@@ -29,9 +29,13 @@ local character = "🐄" --
 local xc, yc = 14, 5
 
 terminal.initwrap(function()
-  local top = position.set_seq(position.get())
+  terminal.output.write("use arrows to move the cow, esc to exit\n")
   terminal.output.write(background)
-  local bottom = position.set_seq(position.get())
+  local top, bottom do
+    local r, c = position.get()
+    bottom = position.set_seq(r, c)
+    top = position.set_seq(r - 10, 1)
+  end
 
   terminal.cursor.visible.set(false)
 

--- a/examples/cow.lua
+++ b/examples/cow.lua
@@ -1,0 +1,70 @@
+local terminal = require("terminal")
+local position = require("terminal.cursor.position")
+local Sequence = require("terminal.sequence")
+local utils    = require("terminal.utils")
+
+local keys = terminal.input.keymap.get_keys()
+local keymap = terminal.input.keymap.get_keymap {
+  ["j"] = keys.down,
+  ["k"] = keys.up,
+  ["h"] = keys.left,
+  ["l"] = keys.right,
+  ["ctrl_c"] = keys.escape
+}
+
+local background =
+[[
+🙶🙸-====-🙠 ^🙧 🙴.🙥 %🙡 -=====-🙸🙷
+|                           |
+|   ---------------------   🙖
+🙑  | 🙾               🌙  |  |
+|  |        /            |  |
+|  |  _🌷_  __/  ___ _   |  🙑
+|  _-___________________-_  |
+| /---/--/-/-+-\-\--\--\--\ |
+|/__/_/_/----+-----\__\____\|
+➹------/🙠 ^🙧 🙴.🙥 %🙡 \--------
+]]
+local character = "🐄" --
+local xc, yc = 14, 5
+
+terminal.initwrap(function()
+  local top = position.set_seq(position.get())
+  terminal.output.write(background)
+  local bottom = position.set_seq(position.get())
+
+  terminal.cursor.visible.set(false)
+
+  local renderer = Sequence(
+    top,
+    background,
+    top,
+    function()
+      return position.move_seq(yc, xc)
+    end,
+    character,
+    bottom
+  )
+
+  while true do
+    terminal.output.write(renderer)
+    local keyname = keymap[terminal.input.readansi(0.02)]
+    if keyname == keys.up then
+      yc = utils.resolve_index(yc - 1, 5, 4)
+
+    elseif keyname == keys.down then
+      yc = utils.resolve_index(yc + 1, 5, 4)
+
+    elseif keyname == keys.left then
+      xc = utils.resolve_index(xc - 1, 23, 5)
+
+    elseif keyname == keys.right then
+      xc = utils.resolve_index(xc + 1, 23, 5)
+
+    elseif keyname == keys.escape then
+      terminal.cursor.visible.set(true)
+      print('Moo!')
+      break
+    end
+  end
+end)()

--- a/spec/06-cursor_spec.lua
+++ b/spec/06-cursor_spec.lua
@@ -406,35 +406,43 @@ describe("Cursor", function()
   end)
 
   describe("position.stack.push_seq()", function()
+    local old_get
+    setup(function()
+      old_get = cursor.position.get
+    end)
+    teardown(function()
+      cursor.position.get = old_get
+    end)
+
     it("returns ANSI sequence for moving to a new position", function()
       -- mock position.get to return fixed values
-      local old_get = cursor.position.get
       cursor.position.get = function() return 2, 3 end
 
       local seq = cursor.position.stack.push_seq(5, 10)
       assert.are.equal(cursor.position.set_seq(5, 10), seq)
-
-      cursor.position.get = old_get
-  end)
+    end)
 
 
     it("returns empty string when no position is provided", function()
-      -- mock position.get to return fixed values
-      local old_get = cursor.position.get
       cursor.position.get = function() return 2, 3 end
 
       assert.are.equal("", cursor.position.stack.push_seq())
-
-      cursor.position.get = old_get
     end)
   end)
 
 
 
   describe("position.stack.pop_seq()", function()
+    local old_get
+    setup(function()
+      old_get = cursor.position.get
+    end)
+    teardown(function()
+      cursor.position.get = old_get
+    end)
+
     it("returns ANSI sequence for moving to the previous position", function()
       -- mock position.get to return fixed values
-      local old_get = cursor.position.get
 
       cursor.position.get = function() return 2, 3 end
 
@@ -444,14 +452,11 @@ describe("Cursor", function()
 
       assert.are.equal(cursor.position.set_seq(5, 10), cursor.position.stack.pop_seq())
       assert.are.equal(cursor.position.set_seq(2, 3), cursor.position.stack.pop_seq())
-
-      cursor.position.get = old_get
     end)
 
 
     it("pops multiple items at once", function()
       -- mock position.get to return different positions
-      local old_get = cursor.position.get
       local positions = { { 1, 1 }, { 2, 2 }, { 3, 3 }, { 4, 4 }, { 5, 5 } }
       local index = 0
 
@@ -467,8 +472,6 @@ describe("Cursor", function()
 
       -- Pop 3 positions at once, should return sequence for position 2
       assert.are.equal(cursor.position.set_seq(3, 3), cursor.position.stack.pop_seq(3))
-
-      cursor.position.get = old_get
     end)
 
 
@@ -487,7 +490,6 @@ describe("Cursor", function()
 
     it("over-popping returns empty string", function()
       -- mock position.get to return fixed values
-      local old_get = cursor.position.get
       cursor.position.get = function() return 2, 3 end
 
       cursor.position.stack.push_seq() -- push position
@@ -495,8 +497,6 @@ describe("Cursor", function()
       -- Pop way more than we pushed
       assert.are.equal(cursor.position.set_seq(2, 3), cursor.position.stack.pop_seq(1)) -- first pop works
       assert.are.equal("", cursor.position.stack.pop_seq(100))                          -- over-popping
-
-      cursor.position.get = old_get
     end)
   end)
 end)

--- a/spec/06-cursor_spec.lua
+++ b/spec/06-cursor_spec.lua
@@ -403,16 +403,24 @@ describe("Cursor", function()
     pending("negative indices", function()
       -- TODO: implement
     end)
+
   end)
 
+
+
   describe("position.stack.push_seq()", function()
+
     local old_get
+
     setup(function()
       old_get = cursor.position.get
     end)
+
+
     teardown(function()
       cursor.position.get = old_get
     end)
+
 
     it("returns ANSI sequence for moving to a new position", function()
       -- mock position.get to return fixed values
@@ -428,18 +436,24 @@ describe("Cursor", function()
 
       assert.are.equal("", cursor.position.stack.push_seq())
     end)
+
   end)
 
 
 
   describe("position.stack.pop_seq()", function()
+
     local old_get
+
     setup(function()
       old_get = cursor.position.get
     end)
+
+
     teardown(function()
       cursor.position.get = old_get
     end)
+
 
     it("returns ANSI sequence for moving to the previous position", function()
       -- mock position.get to return fixed values
@@ -498,5 +512,7 @@ describe("Cursor", function()
       assert.are.equal(cursor.position.set_seq(2, 3), cursor.position.stack.pop_seq(1)) -- first pop works
       assert.are.equal("", cursor.position.stack.pop_seq(100))                          -- over-popping
     end)
+
   end)
+
 end)

--- a/spec/06-cursor_spec.lua
+++ b/spec/06-cursor_spec.lua
@@ -403,7 +403,100 @@ describe("Cursor", function()
     pending("negative indices", function()
       -- TODO: implement
     end)
-
   end)
 
+  describe("position.stack.push_seq()", function()
+    it("returns ANSI sequence for moving to a new position", function()
+      -- mock position.get to return fixed values
+      local old_get = cursor.position.get
+      cursor.position.get = function() return 2, 3 end
+
+      local seq = cursor.position.stack.push_seq(5, 10)
+      assert.are.equal(cursor.position.set_seq(5, 10), seq)
+
+      cursor.position.get = old_get
+  end)
+
+
+    it("returns empty string when no position is provided", function()
+      -- mock position.get to return fixed values
+      local old_get = cursor.position.get
+      cursor.position.get = function() return 2, 3 end
+
+      assert.are.equal("", cursor.position.stack.push_seq())
+
+      cursor.position.get = old_get
+    end)
+  end)
+
+
+
+  describe("position.stack.pop_seq()", function()
+    it("returns ANSI sequence for moving to the previous position", function()
+      -- mock position.get to return fixed values
+      local old_get = cursor.position.get
+
+      cursor.position.get = function() return 2, 3 end
+
+      cursor.position.stack.push_seq() -- push current position (2,3)
+      cursor.position.get = function() return 5, 10 end
+      cursor.position.stack.push_seq() -- push another position (5,10)
+
+      assert.are.equal(cursor.position.set_seq(5, 10), cursor.position.stack.pop_seq())
+      assert.are.equal(cursor.position.set_seq(2, 3), cursor.position.stack.pop_seq())
+
+      cursor.position.get = old_get
+    end)
+
+
+    it("pops multiple items at once", function()
+      -- mock position.get to return different positions
+      local old_get = cursor.position.get
+      local positions = { { 1, 1 }, { 2, 2 }, { 3, 3 }, { 4, 4 }, { 5, 5 } }
+      local index = 0
+
+      cursor.position.get = function()
+        index = index + 1
+        return positions[index][1], positions[index][2]
+      end
+
+      -- Push multiple positions
+      for _ = 1, 5 do
+        cursor.position.stack.push_seq()
+      end
+
+      -- Pop 3 positions at once, should return sequence for position 2
+      assert.are.equal(cursor.position.set_seq(3, 3), cursor.position.stack.pop_seq(3))
+
+      cursor.position.get = old_get
+    end)
+
+
+    it("returns empty string when popping from empty stack", function()
+      -- Create a clean stack
+      for mod in pairs(package.loaded) do
+        if mod:match("^terminal") then
+          package.loaded[mod] = nil
+        end
+      end
+      cursor = require "terminal.cursor"
+
+      assert.are.equal("", cursor.position.stack.pop_seq())
+    end)
+
+
+    it("over-popping returns empty string", function()
+      -- mock position.get to return fixed values
+      local old_get = cursor.position.get
+      cursor.position.get = function() return 2, 3 end
+
+      cursor.position.stack.push_seq() -- push position
+
+      -- Pop way more than we pushed
+      assert.are.equal(cursor.position.set_seq(2, 3), cursor.position.stack.pop_seq(1)) -- first pop works
+      assert.are.equal("", cursor.position.stack.pop_seq(100))                          -- over-popping
+
+      cursor.position.get = old_get
+    end)
+  end)
 end)

--- a/src/terminal/cursor/position/stack.lua
+++ b/src/terminal/cursor/position/stack.lua
@@ -14,16 +14,16 @@ local _positionstack = {}
 
 --- Pushes the current cursor position onto the stack, and returns an ansi sequence to move to the new position (if applicable) without writing it to the terminal.
 -- Calls `position.get` under the hood.
--- @tparam[opt] number row
--- @tparam[opt] number column
--- @treturn string ansi sequence to write to the terminal
+-- @tparam[opt] number new_row
+-- @tparam[opt] number new_column
+-- @treturn string ansi sequence to write to the terminal, or an empty string if no position is given
 -- @within Sequences
-function M.push_seq(row, column)
+function M.push_seq(new_row, new_column)
   local r, c = pos.get()
   -- ignore the error, since we need to keep the stack in sync for pop/push operations
   _positionstack[#_positionstack + 1] = { r, c }
-  if row or column then
-    return pos.set_seq(row, column)
+  if new_row or new_column then
+    return pos.set_seq(new_row, new_column)
   end
   return ""
 end
@@ -32,11 +32,11 @@ end
 
 --- Pushes the current cursor position onto the stack, and writes an ansi sequence to move to the new position (if applicable) to the terminal.
 -- Calls `position.get` under the hood.
--- @tparam[opt] number row
--- @tparam[opt] number column
+-- @tparam[opt] number new_row
+-- @tparam[opt] number new_column
 -- @return true
-function M.push(row, column)
-  output.write(M.push_seq(row, column))
+function M.push(new_row, new_column)
+  output.write(M.push_seq(new_row, new_column))
   return true
 end
 

--- a/src/terminal/cursor/position/stack.lua
+++ b/src/terminal/cursor/position/stack.lua
@@ -22,7 +22,10 @@ function M.push_seq(row, column)
   local r, c = pos.get()
   -- ignore the error, since we need to keep the stack in sync for pop/push operations
   _positionstack[#_positionstack + 1] = { r, c }
-  return (row and column) and pos.set_seq(row, column) or ""
+  if row or column then
+    return pos.set_seq(row, column)
+  end
+  return ""
 end
 
 
@@ -33,7 +36,7 @@ end
 -- @tparam[opt] number column
 -- @return true
 function M.push(row, column)
-  output.write((row and column) and M.push_seq(row, column) or "")
+  output.write(M.push_seq(row, column))
   return true
 end
 

--- a/src/terminal/cursor/position/stack.lua
+++ b/src/terminal/cursor/position/stack.lua
@@ -12,30 +12,28 @@ local _positionstack = {}
 
 
 
---- Pushes the current cursor position onto the stack, and returns an ansi sequence to move to
--- the new position without writing it to the terminal.
+--- Pushes the current cursor position onto the stack, and returns an ansi sequence to move to the new position (if applicable) without writing it to the terminal.
 -- Calls `position.get` under the hood.
--- @tparam number row
--- @tparam number column
+-- @tparam[opt] number row
+-- @tparam[opt] number column
 -- @treturn string ansi sequence to write to the terminal
 -- @within Sequences
 function M.push_seq(row, column)
   local r, c = pos.get()
   -- ignore the error, since we need to keep the stack in sync for pop/push operations
   _positionstack[#_positionstack + 1] = { r, c }
-  return pos.set_seq(row, column)
+  return (row and column) and pos.set_seq(row, column) or ""
 end
 
 
 
---- Pushes the current cursor position onto the stack, and writes an ansi sequence to move to
--- the new position to the terminal.
+--- Pushes the current cursor position onto the stack, and writes an ansi sequence to move to the new position (if applicable) to the terminal.
 -- Calls `position.get` under the hood.
--- @tparam number row
--- @tparam number column
+-- @tparam[opt] number row
+-- @tparam[opt] number column
 -- @return true
 function M.push(row, column)
-  output.write(M.push_seq(row, column))
+  output.write((row and column) and M.push_seq(row, column) or "")
   return true
 end
 


### PR DESCRIPTION
Moo! I was making a cow example and wonder, ? why is `cursor.position.stack.push` has signature 
```
cursor.position.stack.push(row, col)
```
and not just 
``` 
cursor.position.stack.push()
```

Looking at `examples/sequence`, I would see how having the parameters help with moving the cursor, but I imagine most use cases of `push` wouldn't need to do that (as in cow example) 

My fix: remove the two parameters and use result from `position.get()` instead 