### PR TITLE
feat(prompt): finish prompt advanced keybindings

### DIFF
--- a/spec/09-utf8edit_spec.lua
+++ b/spec/09-utf8edit_spec.lua
@@ -54,12 +54,17 @@ describe("Utf8editLine:", function()
       local line = Utf8edit({
         value = "hello",
         position = 3,
-        word_delimiters = [[123456]]
+        word_delimiters = [[abcd]]
       })
       assert.are.equal("hello", tostring(line))
       assert.are.equal(3, line:pos_char())
       assert.are.equal(3, line:pos_col())
-      assert.are.equal([[123456]], line.word_delimiters)
+      assert.are.same({
+        a = true,
+        b = true,
+        c = true,
+        d = true,
+      }, line.word_delimiters)
     end)
 
 
@@ -67,12 +72,17 @@ describe("Utf8editLine:", function()
       local line = Utf8edit({
         value = "こんにちは",
         position = 3,
-        word_delimiters = [[123456]]
+        word_delimiters = [[abcd]]
       })
       assert.are.equal("こんにちは", tostring(line))
       assert.are.equal(3, line:pos_char())
       assert.are.equal(5, line:pos_col())
-      assert.are.equal([[123456]], line.word_delimiters)
+      assert.are.same({
+        a = true,
+        b = true,
+        c = true,
+        d = true,
+      }, line.word_delimiters)
     end)
 
     it("initializes cursor position at the end", function()
@@ -909,14 +919,13 @@ describe("Utf8editLine:", function()
       assert.are.equal(21, line:pos_col())
     end)
 
-    -- TODO: is_delimiter needs to support UTF8
-    pending("skips over consecutive spaces", function()
+    it("skips over consecutive spaces", function()
       local line = Utf8edit("(╯°□°) ╯︵        ┻━┻)")
-      --                      |                ^ 1st left_word()
-      --                      ^ 2nd left_word()
+      --                            |          ^ 1st left_word()
+      --                            ^ 2nd left_word()
       line:left_word(2)
       assert.are.equal(8, line:pos_char())
-      assert.are.equal(19, line:pos_col())
+      assert.are.equal(8, line:pos_col())
     end)
 
     it("go to line start if there's only delimiters to the left ", function()

--- a/spec/09-utf8edit_spec.lua
+++ b/spec/09-utf8edit_spec.lua
@@ -21,6 +21,18 @@ describe("Utf8editLine:", function()
     end)
 
 
+    it("defaults to an empty string with an empty table", function()
+      local line = Utf8edit {}
+      assert.are.equal("", tostring(line))
+    end)
+
+
+    it("defaults to an empty string with an irrelevant table", function()
+      local line = Utf8edit { is_lua_terminal_cool = true }
+      assert.are.equal("", tostring(line))
+    end)
+
+
     it("initializes with a given string", function()
       local line = Utf8edit("hello")
       assert.are.equal("hello", tostring(line))
@@ -38,6 +50,30 @@ describe("Utf8editLine:", function()
       assert.are.equal("こんにちは", tostring(line))
     end)
 
+    it("initializes with a given table (ASCII)", function()
+      local line = Utf8edit({
+        value = "hello",
+        position = 3,
+        word_delimiters = [[123456]]
+      })
+      assert.are.equal("hello", tostring(line))
+      assert.are.equal(3, line:pos_char())
+      assert.are.equal(3, line:pos_col())
+      assert.are.equal([[123456]], line.word_delimiters)
+    end)
+
+
+    it("initializes with a given table (UTF8)", function()
+      local line = Utf8edit({
+        value = "こんにちは",
+        position = 3,
+        word_delimiters = [[123456]]
+      })
+      assert.are.equal("こんにちは", tostring(line))
+      assert.are.equal(3, line:pos_char())
+      assert.are.equal(5, line:pos_col())
+      assert.are.equal([[123456]], line.word_delimiters)
+    end)
 
     it("initializes cursor position at the end", function()
       local line = Utf8edit("hello")

--- a/spec/09-utf8edit_spec.lua
+++ b/spec/09-utf8edit_spec.lua
@@ -826,4 +826,96 @@ describe("Utf8editLine:", function()
 
   end)
 
+
+
+  describe("left_word()", function()
+
+    it("moves the cursor to the start of the previous word (ASCII)", function()
+      local line = Utf8edit("hello world")
+      line:left_word()
+      assert.are.equal(7, line:pos_char())  -- cursor should be at the start of "world"
+      assert.are.equal(7, line:pos_col())
+    end)
+
+
+    it("moves the cursor to the start of the previous word (UTF-8)", function()
+      local line = Utf8edit("你好 thế giới")
+      line:left_word()
+      assert.are.equal(8, line:pos_char())  -- cursor should be at the start of "giới"
+      assert.are.equal(10, line:pos_col())
+    end)
+  end)
+
+
+
+  describe("right_word()", function()
+
+    it("moves the cursor to the start of the next word (ASCII)", function()
+      local line = Utf8edit("hello world")
+      line:goto_home()
+      line:right_word()
+      assert.are.equal(7, line:pos_char())  -- cursor should be at the end of "hello"
+      assert.are.equal(7, line:pos_col())
+    end)
+
+
+    it("moves the cursor to the end of the next word (UTF-8)", function()
+      local line = Utf8edit("你好 thế giới")
+      line:goto_home()
+      line:right_word()
+      assert.are.equal(4, line:pos_char())  -- cursor should be at the end of "你好"
+      assert.are.equal(6, line:pos_col())
+    end)
+  end)
+
+
+
+  describe("backspace_word()", function()
+
+    it("deletes the word to the left of the cursor (ASCII)", function()
+      local line = Utf8edit("hello my world")
+      line:left_word()
+      line:backspace_word()
+      assert.are.equal("hello world", tostring(line))  -- "my" should be deleted
+      assert.are.equal(7, line:pos_char())
+      assert.are.equal(7, line:pos_col())
+    end)
+
+
+    it("deletes the word to the left of the cursor (UTF-8)", function()
+      local line = Utf8edit("你好 thế giới")
+      line:left_word()
+      line:backspace_word()
+      assert.are.equal("你好 giới", tostring(line)) -- "thế" should be deleted
+      assert.are.equal(4, line:pos_char())
+      assert.are.equal(6, line:pos_col())
+    end)
+  end)
+
+
+
+  describe("delete_word()", function()
+
+    it("deletes the word to the right of the cursor (ASCII)", function()
+      local line = Utf8edit("hello my world")
+      line:left_word()
+      line:left_word()
+      line:delete_word()
+      assert.are.equal("hello  world", tostring(line))  -- "world" should be deleted
+      assert.are.equal(7, line:pos_char())
+      assert.are.equal(7, line:pos_col())
+    end)
+
+
+    it("deletes the word to the right of the cursor (UTF-8)", function()
+      local line = Utf8edit("你好 thế giới")
+      line:left_word()
+      line:left_word()
+      line:delete_word()
+      assert.are.equal("你好  giới", tostring(line)) -- "thế" should be deleted
+      assert.are.equal(4, line:pos_char())
+      assert.are.equal(6, line:pos_col())
+    end)
+  end)
+
 end)

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -88,14 +88,13 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
 -- @tparam[opt=80] number opts.max_length The maximum length of the input.
 -- @treturn Prompt A new Prompt instance.
 function Prompt:init(opts)
-  self.value = UTF8EditLine(opts.value or "")
+  self.value = UTF8EditLine({
+    value = opts.value,
+    word_delimiters = opts.word_delimiters,
+    position = opts.position,
+  })
   self.prompt = opts.prompt or ""         -- the prompt to display
   self.max_length = opts.max_length or 80 -- the maximum length of the input
-  if opts.position then
-    local pos = utils.resolve_index(opts.position, self.value:len_char(), 1)
-    self.value:goto_home()
-    self.value:right(pos - 1)
-  end
 end
 
 --- Draw the whole thing: prompt and input value.

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -170,6 +170,8 @@ function Prompt:handleInput()
         end
         if redraw then
           self:drawInput()
+        else
+          self:updateCursor()
         end
       elseif keyname == keys.escape and self.cancellable then
         return "cancelled"

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -78,35 +78,44 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
 -- @tparam[opt=""] string opts.prompt The prompt text to display.
 -- @tparam[opt=""] string opts.value The initial value of the prompt.
 -- @tparam[opt=80] number opts.max_length The maximum length of the input.
--- @tparam[opt=false] boolean opts.drawn_before If the prompt has been drawn before.
 -- @treturn Prompt A new Prompt instance.
 function Prompt:init(opts)
   self.value = UTF8EditLine(opts.value or "")
   self.prompt = opts.prompt or ""          -- the prompt to display
   self.max_length = opts.max_length or 80  -- the maximum length of the input
-  self.drawn_before = false                -- if the prompt has been drawn
 end
 
 
 
---- Draw the prompt and input value.
+--- Draw the whole thing: prompt and input value.
 -- This function writes the prompt and the current input value to the terminal.
--- @tparam boolean redraw ????
 -- @return nothing
-function Prompt:draw(redraw)
-  if redraw or not self.prompt_ready then
-    -- we are at start of prompt
-    self.prompt_ready = true
-    t.cursor.position.column(1)
-    output.write(tostring(self.prompt))
-  else
-    -- we are at current cursor position, move to start of prompt
-    t.cursor.position.column(width.utf8swidth(self.prompt) + 1)
-  end
+function Prompt:draw()
+  -- hide the cursor
+  t.cursor.visible.set(false)
+  -- move to the left margin
+  t.cursor.position.column(1)
   -- write prompt & value
-  local value = tostring(self.value)
-  output.write(value)
+  output.write(tostring(self.prompt))
+  output.write(tostring(self.value))
   output.write(t.clear.eol_seq())
+  self:updateCursor()
+  -- clear remainder of input size
+  output.flush()
+end
+
+--- Draw the input value where the prompt ends.
+-- This function writes input value to the terminal.
+-- @return nothing
+function Prompt:drawInput()
+  -- hide the cursor
+  t.cursor.visible.set(false)
+  -- move to end of prompt
+  t.cursor.position.column(width.utf8swidth(self.prompt) + 1)
+  -- write value
+  output.write(tostring(self.value))
+  output.write(t.clear.eol_seq())
+  self:updateCursor()
   -- clear remainder of input size
   output.flush()
 end
@@ -152,9 +161,8 @@ function Prompt:handleInput()
           handle_action(self.value)
         end
         if redraw then
-          self:draw(false)
+          self:drawInput()
         end
-        self:updateCursor()
       elseif keyname == keys.escape and self.cancellable then
         return "cancelled"
       elseif keyname == keys.enter then
@@ -166,8 +174,7 @@ function Prompt:handleInput()
         t.bell()
       else -- add the character at the current cursor
         self.value:insert(key)
-        self:draw(false)
-        self:updateCursor()
+        self:drawInput()
       end
     end
   end

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -77,12 +77,18 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
 -- @tparam table opts Options for the prompt.
 -- @tparam[opt=""] string opts.prompt The prompt text to display.
 -- @tparam[opt=""] string opts.value The initial value of the prompt.
+-- @tparam[opt=len_char] number opts.position The initial cursor position (in char) of the input
 -- @tparam[opt=80] number opts.max_length The maximum length of the input.
 -- @treturn Prompt A new Prompt instance.
 function Prompt:init(opts)
   self.value = UTF8EditLine(opts.value or "")
   self.prompt = opts.prompt or ""          -- the prompt to display
   self.max_length = opts.max_length or 80  -- the maximum length of the input
+  if opts.position then
+    local pos = utils.resolve_index(opts.position, self.value:len_char(), 1)
+    self.value:goto_home()
+    self.value:right(pos - 1)
+  end
 end
 
 
@@ -130,6 +136,8 @@ end
 function Prompt:updateCursor(column)
   -- move to cursor position
   t.cursor.position.column(column or width.utf8swidth(self.prompt) + self.value.ocursor)
+  -- unhide the cursor
+  t.cursor.visible.set(true)
 end
 
 

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -41,18 +41,23 @@ Prompt.keyname2actions = {
   ["end"] = "goto_end",
   -- emacs keybinding
   ["ctrl_f"] = "left",
+  ["alt_b"] = "left_word",
   ["ctrl_b"] = "right",
+  ["alt_f"] = "right_word",
   ["ctrl_a"] = "goto_home",
   ["ctrl_e"] = "goto_end",
   ["ctrl_h"] = "backspace",
-  ["ctrl_w"] = "backspace_word",     -- TODO: implement
   ["ctrl_u"] = "backspace_to_start",
+  ["ctrl_w"] = "backspace_word",
   ["ctrl_d"] = "delete",
   ["ctrl_k"] = "delete_to_end",
+  ["alt_d"] = "delete_word",
   ["ctrl_l"] = "clear",
-  ["alt_b"] = "left_word",           -- TODO: implement
-  ["alt_f"] = "right_word",          -- TODO: implement
-  ["alt_d"] = "delete_word",         -- TODO: implement
+  -- other keybindings
+  ["ctrl_left"] = "left_word",
+  ["ctrl_right"] = "right_word",
+  -- ["ctrl_backspace ???"] = "backspace_word", -- TODO: if backspace is ctrl + h, how does ctrl + backspace work?
+  -- ["ctrl_deelte ???"] -- TODO: same as above
 }
 
 Prompt.actions2redraw = utils.make_lookup("actions", {
@@ -65,6 +70,8 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
   ["clear"] = true,
   --
   ["left"] = false,
+  ["left_word"] = false,
+  ["right_word"] = false,
   ["right"] = false,
   ["up"] = false,
   ["down"] = false,
@@ -82,16 +89,14 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
 -- @treturn Prompt A new Prompt instance.
 function Prompt:init(opts)
   self.value = UTF8EditLine(opts.value or "")
-  self.prompt = opts.prompt or ""          -- the prompt to display
-  self.max_length = opts.max_length or 80  -- the maximum length of the input
+  self.prompt = opts.prompt or ""         -- the prompt to display
+  self.max_length = opts.max_length or 80 -- the maximum length of the input
   if opts.position then
     local pos = utils.resolve_index(opts.position, self.value:len_char(), 1)
     self.value:goto_home()
     self.value:right(pos - 1)
   end
 end
-
-
 
 --- Draw the whole thing: prompt and input value.
 -- This function writes the prompt and the current input value to the terminal.
@@ -126,8 +131,6 @@ function Prompt:drawInput()
   output.flush()
 end
 
-
-
 -- Update the cursor position.
 -- This function moves the cursor to the current position based on the prompt and input value.
 -- @tparam number column The column to move the cursor to. If not provided, it defaults to the end of
@@ -140,15 +143,11 @@ function Prompt:updateCursor(column)
   t.cursor.visible.set(true)
 end
 
-
-
 -- Read and normalize key input
 function Prompt:readKey()
   local key = t.input.readansi(math.huge)
   return key, keymap[key] or key
 end
-
-
 
 --- Processes key input async
 -- This function listens for key events and processes them.
@@ -177,7 +176,7 @@ function Prompt:handleInput()
         return "cancelled"
       elseif keyname == keys.enter then
         return "returned"
-      -- TODO: wait for luasystem's new readansi release
+        -- TODO: wait for luasystem's new readansi release
       elseif t.input.keymap.is_printable(key) == false then
         t.bell()
       elseif self.value.ilen >= self.max_length or utf8.len(key) ~= 1 then
@@ -189,8 +188,6 @@ function Prompt:handleInput()
     end
   end
 end
-
-
 
 --- Starts the prompt input loop.
 -- This function initializes the input loop for the readline instance.
@@ -211,7 +208,5 @@ function Prompt:run()
     return nil, status
   end
 end
-
-
 
 return Prompt

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -37,7 +37,11 @@ function UTF8EditLine:__tostring()
   return table.concat(res)
 end
 
+-- TODO: Should i setter/getter this? 👇
 
+--- A list of word delimiters for word-wise navigation
+-- @string word_delimiters
+UTF8EditLine.word_delimiters = [[/\()"'-.,:;<>~!@#$%^&*|+=[]{}~?│ ]]
 
 --- Creates a new `utf8edit` instance. This method is invoked by calling on the class.
 -- The cursor position will be at the end of the string.
@@ -272,6 +276,75 @@ function UTF8EditLine:delete_to_end()
   end
 end
 
+--- Checks if the current character is a word delimiter.
+-- @tparam table node the node to check
+-- @treturn boolean true if the character is a word delimiter, false otherwise
+function UTF8EditLine:is_delimiter(node)
+  local char = node.value or ""
+  -- use non-pattern matching
+  return self.word_delimiters:find(char, 1, true) ~= nil
+end
 
+
+--- Moves the cursor to the start of the current word. If already at start, moves to the start of the previous word.
+-- This function moves the cursor left until it reaches the start of the previous word.
+-- Words are defined by non-delimiter characters.
+function UTF8EditLine:left_word()
+  if self:is_delimiter(self.icursor.prev) then
+    self:left()
+  end
+  while self.icursor.prev ~= self.head do
+    -- non-pattern matching
+    if self:is_delimiter(self.icursor.prev) then
+      break
+    end
+    self:left()
+  end
+end
+
+--- Moves the cursor to the start of the next word.
+-- This function moves the cursor right until it reaches the end of the next word.
+-- Words are defined by non-delimiter characters.
+function UTF8EditLine:right_word()
+  while self.icursor ~= self.tail do
+    if self:is_delimiter(self.icursor) then
+      break
+    end
+    self:right()
+  end
+  while self.icursor ~= self.tail do
+    if not self:is_delimiter(self.icursor) then
+      break
+    end
+    self:right()
+  end
+end
+
+--- Backspace until the start of the current word. If at the start, backspace to the start of the previous word.
+-- Words are defined by non-delimiter characters.
+function UTF8EditLine:backspace_word()
+  if self:is_delimiter(self.icursor.prev) then
+    self:backspace()
+  end
+  while self.icursor.prev ~= self.head do
+    -- non-pattern matching
+    if self:is_delimiter(self.icursor.prev) then
+      break
+    end
+    self:backspace()
+  end
+end
+
+--- Delete until the end of the current word.
+-- Words are defined by non-delimiter characters.
+function UTF8EditLine:delete_word()
+  while self.icursor ~= self.tail do
+    -- non-pattern matching
+    if self:is_delimiter(self.icursor) then
+      break
+    end
+    self:delete()
+  end
+end
 
 return UTF8EditLine

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -50,7 +50,7 @@ UTF8EditLine.word_delimiters = [[/\()"'-.,:;<>~!@#$%^&*|+=[]{}~?│ ]]
 -- @usage
 -- local Utf8edit = require("terminal.utf8edit")
 -- local newLineObj = Utf8edit("héllo界")
-function UTF8EditLine:init(s)
+function UTF8EditLine:init(opts)
   self.icursor = {}          -- tracking the cursor internally (utf8 characters)
   self.ocursor = 1           -- tracking the cursor externally (columns)
   self.ilen = 0              -- tracking the length internally (# of utf8 characters)
@@ -59,8 +59,16 @@ function UTF8EditLine:init(s)
   self.tail = self.icursor   -- prepare linked list
   self.tail.prev = self.head
   self.head.next = self.tail
-  if s then
-    self:insert(s)
+  if type(opts) == "table" then
+    self:insert(opts.value)
+    self.word_delimiters = opts.word_delimiters
+    if opts.position then
+      local pos = utils.resolve_index(opts.position, self:len_char(), 1)
+      self:goto_home()
+      self:right(pos - 1)
+    end
+  else
+    self:insert(opts)
   end
 end
 

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -301,14 +301,12 @@ end
 function UTF8EditLine:left_word(n)
   for _ = 1, n or 1 do
     while self.icursor.prev ~= self.head do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor.prev) == false then
         break
       end
       self:left()
     end
     while self.icursor.prev ~= self.head do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor.prev) then
         break
       end
@@ -344,14 +342,12 @@ end
 function UTF8EditLine:backspace_word(n)
   for _ = 1, n or 1 do
     while self.icursor.prev ~= self.head do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor.prev) == false then
         break
       end
       self:backspace()
     end
     while self.icursor.prev ~= self.head do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor.prev) then
         break
       end
@@ -366,14 +362,12 @@ end
 function UTF8EditLine:delete_word(n)
   for _ = 1, n or 1 do
     while self.icursor ~= self.tail do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor) == false then
         break
       end
       self:delete()
     end
     while self.icursor ~= self.tail do
-      -- non-pattern matching
       if self:is_delimiter(self.icursor) then
         break
       end

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -289,61 +289,73 @@ end
 --- Moves the cursor to the start of the current word. If already at start, moves to the start of the previous word.
 -- This function moves the cursor left until it reaches the start of the previous word.
 -- Words are defined by non-delimiter characters.
-function UTF8EditLine:left_word()
-  if self:is_delimiter(self.icursor.prev) then
-    self:left()
-  end
-  while self.icursor.prev ~= self.head do
-    -- non-pattern matching
+-- @tparam[opt=1] number n the number of words to move left
+function UTF8EditLine:left_word(n)
+  for _ = 1, n or 1 do
     if self:is_delimiter(self.icursor.prev) then
-      break
+      self:left()
     end
-    self:left()
+    while self.icursor.prev ~= self.head do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor.prev) then
+        break
+      end
+      self:left()
+    end
   end
 end
 
 --- Moves the cursor to the start of the next word.
 -- This function moves the cursor right until it reaches the end of the next word.
 -- Words are defined by non-delimiter characters.
-function UTF8EditLine:right_word()
-  while self.icursor ~= self.tail do
-    if self:is_delimiter(self.icursor) then
-      break
+-- @tparam[opt=1] number n the number of words to move left
+function UTF8EditLine:right_word(n)
+  for _ = 1, n or 1 do
+    while self.icursor ~= self.tail do
+      if self:is_delimiter(self.icursor) then
+        break
+      end
+      self:right()
     end
-    self:right()
-  end
-  while self.icursor ~= self.tail do
-    if not self:is_delimiter(self.icursor) then
-      break
+    while self.icursor ~= self.tail do
+      if not self:is_delimiter(self.icursor) then
+        break
+      end
+      self:right()
     end
-    self:right()
   end
 end
 
 --- Backspace until the start of the current word. If at the start, backspace to the start of the previous word.
 -- Words are defined by non-delimiter characters.
-function UTF8EditLine:backspace_word()
-  if self:is_delimiter(self.icursor.prev) then
-    self:backspace()
-  end
-  while self.icursor.prev ~= self.head do
-    -- non-pattern matching
+-- @tparam[opt=1] number n the number of words to move left
+function UTF8EditLine:backspace_word(n)
+  for _ = 1, n or 1 do
     if self:is_delimiter(self.icursor.prev) then
-      break
+      self:backspace()
     end
-    self:backspace()
+    while self.icursor.prev ~= self.head do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor.prev) then
+        break
+      end
+      self:backspace()
+    end
   end
 end
 
 --- Delete until the end of the current word.
 -- Words are defined by non-delimiter characters.
-function UTF8EditLine:delete_word()
-  while self.icursor ~= self.tail do
-    -- non-pattern matching
-    if self:is_delimiter(self.icursor) then
-      break
+-- @tparam[opt=1] number n the number of words to move left
+function UTF8EditLine:delete_word(n)
+  for _ = 1, n or 1 do
+    while self.icursor ~= self.tail do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor) then
+        break
+      end
+      self:delete()
     end
-    self:delete()
   end
 end
 

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -292,7 +292,11 @@ end
 -- @tparam[opt=1] number n the number of words to move left
 function UTF8EditLine:left_word(n)
   for _ = 1, n or 1 do
-    if self:is_delimiter(self.icursor.prev) then
+    while self.icursor.prev ~= self.head do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor.prev) == false then
+        break
+      end
       self:left()
     end
     while self.icursor.prev ~= self.head do
@@ -331,7 +335,11 @@ end
 -- @tparam[opt=1] number n the number of words to move left
 function UTF8EditLine:backspace_word(n)
   for _ = 1, n or 1 do
-    if self:is_delimiter(self.icursor.prev) then
+    while self.icursor.prev ~= self.head do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor.prev) == false then
+        break
+      end
       self:backspace()
     end
     while self.icursor.prev ~= self.head do
@@ -349,6 +357,13 @@ end
 -- @tparam[opt=1] number n the number of words to move left
 function UTF8EditLine:delete_word(n)
   for _ = 1, n or 1 do
+    while self.icursor ~= self.tail do
+      -- non-pattern matching
+      if self:is_delimiter(self.icursor) == false then
+        break
+      end
+      self:delete()
+    end
     while self.icursor ~= self.tail do
       -- non-pattern matching
       if self:is_delimiter(self.icursor) then


### PR DESCRIPTION
This PR: 
- implements `opts.position` for prompt to set intial cursor position 
- word navigation and word text editing for `utf8edit` and `prompt`

tracks #117 