### PR TITLE
feat(utf8edit): horizontal scroll

### DIFF
--- a/examples/prompt.lua
+++ b/examples/prompt.lua
@@ -12,7 +12,9 @@ t.initwrap(function () -- on Windows: wrap for utf8 output
   local result, status = pr:run()
   if result then
     print("Result (string): '" .. result .. "'")
-    print("Result (bytes):", (result or ""):byte(1, -1))
+    print("Result (viewpr): '" .. pr.value:viewport_str() .. "'")
+    print("Result (width_): '" .. pr.value.olen .. "'")
+    print("Result (vwidth): '" .. pr.value.viewport.width .. "'")
   else
     print("Status: " .. (status or "nil"))
   end

--- a/examples/prompt.lua
+++ b/examples/prompt.lua
@@ -4,7 +4,6 @@ local Prompt = require("terminal.cli.prompt")
 local pr = Prompt {
   prompt = "Enter something: ",
   value = "Hello, 你-好 World 🚀!",
-  max_length = 62,
   position = 2,
   cancellable = true,
 }

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -11,7 +11,6 @@
 -- local prompt = Prompt {
 --     prompt = "Enter something: ",
 --     value = "Hello, 你-好 World 🚀!",
---     max_length = 62,
 --     overflow = "wrap" -- or "scroll"   -- TODO: implement
 --     -- cancellable = true, -- TODO: implement
 --     position = 2,

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -89,13 +89,13 @@ Prompt.actions2redraw = utils.make_lookup("actions", {
 function Prompt:init(opts)
   self.prompt = opts.prompt or ""         -- the prompt to display
   local _, columns = t.size()
-  local auto_width = columns - width.utf8swidth(self.prompt) - 3
+  local auto_width = columns - width.utf8swidth(self.prompt) - 2
   self.value = UTF8EditLine({
     value = opts.value,
     word_delimiters = opts.word_delimiters,
     position = opts.position,
     -- viewport_width = opts.viewport_width or auto_width
-    viewport_width = opts.viewport_width or 30
+    viewport_width = opts.viewport_width or auto_width
   })
 end
 
@@ -146,7 +146,10 @@ function Prompt:drawInput()
   -- write end scroll indicator
   output.write(self:endIndicator_seq())
   -- clear till eol
-  output.write(t.clear.eol_seq())
+  local _, c = t.size()
+  if width.utf8swidth(self.prompt) + width.utf8swidth(self.value:viewport_str()) + 2 < c then
+    output.write(t.clear.eol_seq())
+  end
   self:updateCursor()
   -- clear remainder of input size
   output.flush()

--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -218,8 +218,16 @@ end
 function Prompt:run()
   local status
 
+  -- TODO: add this ansi sequence to a attributes module, maybe even in terminal?
+  -- turns autowrap off
+  t.output.write('\027[?7l')
+
   self:draw()
   status = self:handleInput()
+
+  -- restore autowrap
+  t.output.write('\027[?7h')
+
   t.output.print() -- move to new line (we're still on the 'press any key' line)
 
   if status == "returned" then

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -149,17 +149,14 @@ function UTF8EditLine:viewport_str()
 end
 
 function UTF8EditLine:viewport_pos_col()
-  local head = self.viewport.head
+  local head = self.viewport.head.next
 
-  local w = 0
+  local w = 1
   while head do
-    w = w + (head.value and width.utf8swidth(head.value) or 0)
     if head == self.icursor then
-      if head == self.tail then
-        w = w + 1
-      end
       break
     end
+    w = w + (head.value and width.utf8swidth(head.value) or 0)
     head = head.next
   end
   return w

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -258,26 +258,7 @@ end
 -- @return self (for chaining)
 function UTF8EditLine:goto_index(pos)
   pos = utils.resolve_index(pos, self.ilen + 1, 1)
-  if pos < 0 then
-    return self:goto_home()
-  end
-
-  if pos >= self.ilen + 1 then
-    return self:goto_end()
-  end
-
-  local head = self.head.next
-  local l = 1
-  self.ocursor = 1
-  while head do
-    if l == pos then
-      self.icursor = head
-      return self
-    end
-    self.ocursor = self.ocursor + width.utf8cwidth(head.value or "")
-    l = l + 1
-    head = head.next
-  end
+  self:goto_home():right(pos - 1)
   return self
 end
 

--- a/src/terminal/utf8edit.lua
+++ b/src/terminal/utf8edit.lua
@@ -264,10 +264,6 @@ function UTF8EditLine:handle_overflow()
       self.viewport.tail = self.icursor.next
     end
     self:handle_overflow_tail()
-
-  else
-    print(self.icursor, self.viewport.tail)
-    print(self.icursor.value or "?", self.viewport.tail.value)
   end
 end
 


### PR DESCRIPTION
This PR adds the horizontal scroll feature to the UTF8EditLine module and the Prompt widget. 

I might change mind my later on structuring all these new EditLine functions for the viewport, for example they might get migrated to the Prompt widget, since we don't have true private fields in our OOP (`local function` is an option...) @Tieske what do you think? 