### PR TITLE
fix(editline): opening brackets associate right, don't break

### DIFF
--- a/spec/09-editline-format_spec.lua
+++ b/spec/09-editline-format_spec.lua
@@ -903,8 +903,8 @@ describe("EditLine:", function()
           line = EditLine("will go into a single line (not really)"):goto_index(pos)
           assert.are.same({
             'will go |',
-            '|into a single line (',
-            'not really)|',
+            '|into a single line ',
+            '(not really)|',
           }, testwrap({
             width = 20, -- other lines are longer
             first_width = 10,  -- cursor is one beyond last char, so length is one less

--- a/src/terminal/editline.lua
+++ b/src/terminal/editline.lua
@@ -35,7 +35,7 @@ local SINGLE_WIDTH = " "
 local DOUBLE_WIDTH = "  "
 
 --- Default word delimiters for EditLine.
-local WORD_DELIMITERS = [[/\()"'-.,:;<>~!@#$%^&*|+=[]{}~?│ ]] .. "\t"
+local WORD_DELIMITERS = [[/\)"'-.,:;<>~!@#$%^&*|+=]}~?│ ]] .. "\t"
 
 
 


### PR DESCRIPTION
Opening brackets associate to the right, hence wordwrap shouldn't break on those. See the adjusted test case for an example.