### PR TITLE
fix(editline): when formatting firstline can have width < 2

### DIFF
--- a/spec/09-editline-format_spec.lua
+++ b/spec/09-editline-format_spec.lua
@@ -511,6 +511,38 @@ describe("EditLine:", function()
       end)
 
 
+      it("returns an error if width < 2", function()
+        assert.has.error(function()
+          testwrap({
+            width = 1,
+            first_width = 60,
+            wordwrap = false,
+            pad = true,
+            pad_last = false
+          })
+        end)
+      end)
+
+
+      it("returns no error if first_width < 2", function()
+        assert.are.same({
+          '| ',
+          'Hello, this is a simple 🚀 test string to check the formatti|',
+          'ng functionality of |the EditLine class. It features word wra',
+          'pping, padding, and cursor handling. The class supports both|',
+          ' single-width and double-width characters, ensuring correct |',
+          'column calculations 🚀.|',
+        }, testwrap({
+          width = 60,
+          first_width = 1,
+          wordwrap = false,
+          pad = true,
+          pad_last = false
+        }))
+      end)
+
+
+
 
       describe("cursor-position", function()
 
@@ -855,6 +887,37 @@ describe("EditLine:", function()
           wordwrap = true,
           pad = false,
           pad_last = true
+        }))
+      end)
+
+
+      it("returns an error if width < 2", function()
+        assert.has.error(function()
+          testwrap({
+            width = 1,
+            first_width = 60,
+            wordwrap = true,
+            pad = true,
+            pad_last = false
+          })
+        end)
+      end)
+
+
+      it("returns no error if first_width < 2", function()
+        assert.are.same({
+          '| ',
+          'Hello, this is a simple 🚀 test string to check the |        ',
+          'formatting functionality of |the EditLine class. It features ',
+          'word wrapping, padding, and cursor handling. The class |     ',
+          'supports both single-width and double-width characters, |    ',
+          'ensuring correct column calculations 🚀.|',
+        }, testwrap({
+          width = 60,
+          first_width = 1,
+          wordwrap = true,
+          pad = true,
+          pad_last = false
         }))
       end)
 

--- a/src/terminal/editline.lua
+++ b/src/terminal/editline.lua
@@ -586,6 +586,14 @@ do
       cur_col = width - first_width + 1
     end
 
+    if first_width < 2 then
+      -- first_width can be less than 2, if this happens just insert
+      -- an empty line as first line, and continue with normal width
+      lines[1] = EditLine("")
+      line_cols[1] = 0
+      target_size = width
+    end
+
     while self.cursor_idx <= size do
       local line, cols = wrapper(self, target_size)
 -- print("line:", "'"..tostring(line).."'", cols)


### PR DESCRIPTION
width needs to be minimal 2 to format and have double-width chars. first-line width can be less, we simply move everything to the next line.