### PR TITLE
feat(titles): specify left/right/drop fro truncation

### DIFF
--- a/spec/12-draw_spec.lua
+++ b/spec/12-draw_spec.lua
@@ -1,0 +1,140 @@
+describe("terminal.draw", function()
+
+  local line
+
+  before_each(function()
+    line = require("terminal.draw.line")
+  end)
+
+
+  after_each(function()
+    line = nil
+  end)
+
+
+  it("creates title sequence with empty title", function()
+    local result = line.title_seq(10, "")
+    assert.are.equal("──────────", result)
+  end)
+
+
+  it("creates title sequence with nil title", function()
+    local result = line.title_seq(10, nil)
+    assert.are.equal("──────────", result)
+  end)
+
+
+  it("creates title sequence with simple title", function()
+    local result = line.title_seq(10, "Test")
+    assert.are.equal("───Test───", result)
+  end)
+
+
+  it("creates title sequence with custom character", function()
+    local result = line.title_seq(8, "Hi", "=")
+    assert.are.equal("===Hi===", result)
+  end)
+
+
+  it("creates title sequence with prefix and postfix", function()
+    local result = line.title_seq(12, "Title", "─", "┤ ", " ├")
+    assert.are.equal("─┤ Title ├──", result)
+  end)
+
+
+  it("handles exact fit for title", function()
+    local result = line.title_seq(4, "Hi")
+    assert.are.equal("─Hi─", result)
+  end)
+
+
+  it("handles title that's too long - truncates with ellipsis", function()
+    local result = line.title_seq(8, "VeryLongTitle")
+    assert.are.equal("VeryL...", result)
+  end)
+
+
+  it("handles title that's too long with prefix/postfix", function()
+    local result = line.title_seq(10, "VeryLongTitle", "─", "┤ ", " ├")
+    assert.are.equal("┤ Ver... ├", result)
+  end)
+
+
+  it("omits title when width too small (less than 4 chars)", function()
+    local result = line.title_seq(3, "Test")
+    assert.are.equal("───", result)
+  end)
+
+
+  it("omits title when width too small with prefix/postfix", function()
+    local result = line.title_seq(5, "Test", "─", "┤ ", " ├")
+    assert.are.equal("─────", result)
+  end)
+
+
+  it("handles zero width", function()
+    local result = line.title_seq(0, "Test")
+    assert.are.equal("", result)
+  end)
+
+
+  it("handles empty prefix and postfix", function()
+    local result = line.title_seq(8, "Test", "─", "", "")
+    assert.are.equal("──Test──", result)
+  end)
+
+
+  it("handles single character title", function()
+    local result = line.title_seq(5, "A")
+    assert.are.equal("──A──", result)
+  end)
+
+
+  it("handles title with spaces", function()
+    local result = line.title_seq(10, "Hello World")
+    assert.are.equal("Hello W...", result) -- Should truncate
+  end)
+
+
+  it("handles double-width unicode characters in title", function()
+    local result = line.title_seq(8, "测试")
+    assert.are.equal("──测试──", result)
+  end)
+
+
+  it("handles very large width", function()
+    local result = line.title_seq(1000, "Test")
+    assert.is_string(result)
+    -- The result will be longer than 1000 due to the title and padding
+    assert.is_true(#result >= 1000)
+  end)
+
+
+  it("handles very long title", function()
+    local long_title = string.rep("A", 1000)
+    local result = line.title_seq(10, long_title)
+    assert.are.equal("AAAAAAA...", result)
+  end)
+
+
+  it("handles special characters in title", function()
+    local result = line.title_seq(11, "hello 测试!")
+    assert.are.equal("hello 测试!", result)
+
+    local result = line.title_seq(10, "hello 测试!")
+    assert.are.equal("hello ...─", result)
+  end)
+
+
+  it("drops the title if too long and 'drop' is specified", function()
+    local result = line.title_seq(10, "hello 测试!", nil, nil, nil, "drop")
+    assert.are.equal("──────────", result)
+  end)
+
+
+  it("truncates to the left if the title is too long and 'left' is specified", function()
+    local result = line.title_seq(10, "hello 测试!", nil, nil, nil, "left")
+    assert.are.equal("...o 测试!", result)
+  end)
+
+end)

--- a/src/terminal/draw/line.lua
+++ b/src/terminal/draw/line.lua
@@ -71,6 +71,54 @@ end
 
 
 
+--- Formats a title for display in a title line.
+-- Shortens it if necessary, adds ellipsis if necessary. "left" means truncate from the left,
+-- "right" means truncate from the right, "drop" means drop the entire thing all at once.
+--
+-- @tparam number width the available width for the title in columns
+-- @tparam[opt=""] string title the title to format
+-- @tparam[opt="right"] string type the type of truncation to apply, either "left", "right", or "drop"
+-- @treturn string the formatted title, this can be an empty string if it doesn't fit
+-- @treturn number the size of the returned title in columns
+function M.title_fmt(width, title, type)
+  if title == nil or title == "" then
+    return "", 0
+  end
+  type = type or "right"
+  local EditLine = require "terminal.editline"
+
+  local title_w = text.width.utf8swidth(title)
+  if width >= title_w then
+    -- enough space for title
+    return title, title_w
+
+  elseif width < 4 or type == "drop" then
+    -- too little space for title, omit it alltogether
+    return "", 0
+
+  elseif type == "right" then -- truncate the title to the right
+    width = width - 3 -- for "..."
+    local el_title = EditLine(title):goto_index(width+1)
+    while el_title:pos_col() - 1 > width do
+      el_title:left()
+    end
+    el_title = el_title:sub_char(1, el_title:pos_char() - 1)
+    return tostring(el_title) .. "...", el_title:len_col() + 3
+
+  else -- truncate the title to the left
+    width = width - 3 -- for "..."
+    local el_title = EditLine(title):left(width + 1)
+    local l = el_title:len_col()
+    while l - el_title:pos_col() >= width do
+      el_title:right()
+    end
+    el_title = el_title:sub_char(el_title:pos_char(), -1)
+    return "..." .. tostring(el_title), el_title:len_col() + 3
+  end
+end
+
+
+
 --- Creates a sequence to draw a horizontal line with a title centered in it without writing it to the terminal.
 -- Line is drawn left to right. If the width is too small for the title, the title is truncated with "trailing `"..."`.
 -- If less than 4 characters are available for the title, the title is omitted alltogether.
@@ -79,40 +127,30 @@ end
 -- @tparam[opt="─"] string char the line-character to use
 -- @tparam[opt=""] string pre the prefix for the title, eg. "┤ "
 -- @tparam[opt=""] string post the postfix for the title, eg. " ├"
+-- @tparam[opt="right"] string type the type of truncation to apply, either "left", "right", or "drop"
 -- @treturn string ansi sequence to write to the terminal
 -- @within Sequences
-function M.title_seq(width, title, char, pre, post)
-
-  -- TODO: strip any ansi sequences from the title before determining length
-  -- such that titles can have multiple colors etc. what if we truncate????
-
+function M.title_seq(width, title, char, pre, post, type)
   if title == nil or title == "" then
     return M.horizontal_seq(width, char)
   end
+
   pre = pre or ""
   post = post or ""
   local pre_w = text.width.utf8swidth(pre)
   local post_w = text.width.utf8swidth(post)
-  local title_w = text.width.utf8swidth(title)
   local w_for_title = width - pre_w - post_w
-  if w_for_title > title_w then
-    -- enough space for title
-    local p1 = M.horizontal_seq(math.floor((w_for_title - title_w) / 2), char) .. pre .. title .. post
-    return p1 .. M.horizontal_seq(width - text.width.utf8swidth(p1), char)
-  elseif w_for_title < 4 then
-    -- too little space for title, omit it alltogether
+
+  local title, title_w = M.title_fmt(w_for_title, title, type)
+  if title_w == 0 then
     return M.horizontal_seq(width, char)
-  elseif w_for_title == title_w then
-    -- exact space for title
-    return pre .. title .. post
-  else -- truncate the title
-    w_for_title = w_for_title - 3 -- for "..."
-    while title_w == nil or title_w > w_for_title do
-      title = title:sub(1, -2) -- drop last byte
-      title_w = text.width.utf8swidth(title)
-    end
-    return pre .. title .. "..." .. post
   end
+  title = pre .. title .. post
+  title_w = title_w + pre_w + post_w
+
+  local left = math.floor((width - title_w) / 2)
+  local right = width - left - title_w
+  return M.horizontal_seq(left, char) .. title .. M.horizontal_seq(right, char)
 end
 
 


### PR DESCRIPTION
also fixes an issue with cutting bytes of utf-8 chars, and exports the title generator function itself, besides as part of the title line.