### PR TITLE
refactor(panel): content callback no longer takes pos/size args

### DIFF
--- a/examples/panel.lua
+++ b/examples/panel.lua
@@ -9,9 +9,11 @@ local Panel = require("terminal.ui.panel")
 
 
 
--- Helper function to draw content in a panel
-local function draw_content(row, col, height, width, text, color)
+local function draw_content(self, text, color)
   color = color or "white"
+
+  local row, col = self.inner_row, self.inner_col
+  local height, width = self.inner_height, self.inner_width
 
   -- Center the text in the panel
   local text_row = row + math.floor(height / 2)
@@ -58,8 +60,8 @@ local function run_example_1()
   terminal.cursor.position.set(1, 1)
 
   local rows, cols = terminal.size()
-  local simple_panel = create_fullscreen_panel(function(self, row, col, height, width)
-    draw_content(row, col, height, width, "Hello World! Press any key to continue...", "green")
+  local simple_panel = create_fullscreen_panel(function(self)
+    draw_content(self, "Hello World! Press any key to continue...", "green")
   end)
 
   simple_panel:calculate_layout(1, 1, rows, cols)
@@ -86,8 +88,8 @@ local function run_example_2()
     split_ratio = 0.6, -- 60% left, 40% right
     children = {
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "60% - Press any key", "blue")
+        content = function(self)
+          draw_content(self, "60% - Press any key", "blue")
         end,
         border = {
           format = terminal.draw.box_fmt.double,
@@ -96,8 +98,8 @@ local function run_example_2()
         },
       },
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "40%", "red")
+        content = function(self)
+          draw_content(self, "40%", "red")
         end,
         border = {
           format = terminal.draw.box_fmt.double,
@@ -132,8 +134,8 @@ local function run_example_3()
     split_ratio = 0.4, -- 40% top, 60% bottom
     children = {
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "40% - Press any key", "yellow")
+        content = function(self)
+          draw_content(self, "40% - Press any key", "yellow")
         end,
         border = {
           format = terminal.draw.box_fmt.single,
@@ -142,8 +144,8 @@ local function run_example_3()
         },
       },
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "60%", "magenta")
+        content = function(self)
+          draw_content(self, "60%", "magenta")
         end,
         border = {
           format = terminal.draw.box_fmt.single,
@@ -201,8 +203,8 @@ local function run_example_4()
         split_ratio = 0.3,
         children = {
           Panel {
-            content = function(self, row, col, height, width)
-              draw_content(row, col, height, width, "30%", "cyan")
+            content = function(self)
+              draw_content(self, "30%", "cyan")
             end,
             border = {
               format = fmt_top_left,
@@ -211,8 +213,8 @@ local function run_example_4()
             },
           },
           Panel {
-            content = function(self, row, col, height, width)
-              draw_content(row, col, height, width, "70%", "green")
+            content = function(self)
+              draw_content(self, "70%", "green")
             end,
             border = {
               format = fmt_bottom_left,
@@ -224,8 +226,8 @@ local function run_example_4()
       },
       -- Right side: simple content
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "Full Right - Press any key", "red")
+        content = function(self)
+          draw_content(self, "Full Right - Press any key", "red")
         end,
         border = {
           format = fmt_right,
@@ -259,8 +261,8 @@ local function run_example_5()
     split_ratio = 0.5,
     children = {
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "50%", "blue")
+        content = function(self)
+          draw_content(self, "50%", "blue")
         end,
         border = {
           format = terminal.draw.box_fmt.single,
@@ -269,8 +271,8 @@ local function run_example_5()
         },
       },
       Panel {
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "50% - Press any key", "red")
+        content = function(self)
+          draw_content(self, "50% - Press any key", "red")
         end,
         border = {
           format = terminal.draw.box_fmt.single,
@@ -316,8 +318,8 @@ local function run_example_6()
     children = {
       Panel {
         min_width = math.max(15, math.floor(cols * 0.3)), -- Minimum width constraint
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "Min: " .. math.max(15, math.floor(cols * 0.3)), "green")
+        content = function(self)
+          draw_content(self, "Min: " .. math.max(15, math.floor(cols * 0.3)), "green")
         end,
         border = {
           format = terminal.draw.box_fmt.double,
@@ -327,8 +329,8 @@ local function run_example_6()
       },
       Panel {
         max_width = math.min(20, math.floor(cols * 0.7)), -- Maximum width constraint
-        content = function(self, row, col, height, width)
-          draw_content(row, col, height, width, "Max: " .. math.min(20, math.floor(cols * 0.7)) .. " - Press any key", "red")
+        content = function(self)
+          draw_content(self, "Max: " .. math.min(20, math.floor(cols * 0.7)) .. " - Press any key", "red")
         end,
         border = {
           format = terminal.draw.box_fmt.double,

--- a/spec/10-panel_spec.lua
+++ b/spec/10-panel_spec.lua
@@ -17,7 +17,7 @@ describe("terminal.ui.panel", function()
     it("creates a content panel with callback", function()
       local callback_called = false
       local panel = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           callback_called = true
         end
       }
@@ -28,7 +28,7 @@ describe("terminal.ui.panel", function()
       assert.is_nil(panel.orientation)
 
       -- Call the panel's content callback to test it
-      panel:content(1, 1, 10, 20)
+      panel:content()
       assert.is_true(callback_called, "Content callback should have been called")
     end)
 
@@ -547,9 +547,9 @@ describe("terminal.ui.panel", function()
       local callback_args = {}
 
       local panel = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           callback_called = true
-          callback_args = { self, row, col, height, width }
+          callback_args = { self, self.inner_row, self.inner_col, self.inner_height, self.inner_width }
         end
       }
 
@@ -568,13 +568,13 @@ describe("terminal.ui.panel", function()
       local right_callback_called = false
 
       local left_panel = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           left_callback_called = true
         end
       }
 
       local right_panel = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           right_callback_called = true
         end
       }

--- a/spec/11-screen_spec.lua
+++ b/spec/11-screen_spec.lua
@@ -26,7 +26,7 @@ describe("terminal.ui.screen", function()
 
     it("creates a screen with body panel only", function()
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Test content
         end
       }
@@ -50,19 +50,19 @@ describe("terminal.ui.screen", function()
 
     it("creates a screen with header, body, and footer", function()
       local header = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Header content
         end
       }
 
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Body content
         end
       }
 
       local footer = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Footer content
         end
       }
@@ -91,13 +91,13 @@ describe("terminal.ui.screen", function()
 
     it("creates a screen with header and body only", function()
       local header = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Header content
         end
       }
 
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Body content
         end
       }
@@ -120,13 +120,13 @@ describe("terminal.ui.screen", function()
 
     it("creates a screen with body and footer only", function()
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Body content
         end
       }
 
       local footer = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Footer content
         end
       }
@@ -170,7 +170,7 @@ describe("terminal.ui.screen", function()
 
     it("accepts custom name", function()
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Test content
         end
       }
@@ -186,19 +186,19 @@ describe("terminal.ui.screen", function()
 
     it("allows access to panels by name", function()
       local header = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Header content
         end
       }
 
       local body = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Body content
         end
       }
 
       local footer = Panel {
-        content = function(self, row, col, height, width)
+        content = function(self)
           -- Footer content
         end
       }

--- a/spec/13-bar_spec.lua
+++ b/spec/13-bar_spec.lua
@@ -381,9 +381,9 @@ describe("terminal.ui.panel.bar", function()
       -- Mock _draw_bar to track calls
       local called = false
       local call_args = {}
-      bar._draw_bar = function(self, row, col, height, width)
+      bar._draw_bar = function(self)
         called = true
-        call_args = { row, col, height, width }
+        call_args = { self.inner_row, self.inner_col, self.inner_height, self.inner_width }
       end
 
       bar.row = 5

--- a/src/terminal/ui/panel/bar.lua
+++ b/src/terminal/ui/panel/bar.lua
@@ -96,8 +96,8 @@ function Bar:init(opts)
   opts.auto_render = nil
 
   -- Provide content callback for parent constructor
-  opts.content = function(self, row, col, height, width)
-    self:_draw_bar(row, col, height, width)
+  opts.content = function(self)
+    self:_draw_bar()
   end
 
   -- Call parent constructor
@@ -122,16 +122,12 @@ function Bar:init(opts)
 end
 
 -- Private method to draw the bar content.
--- @tparam number row Starting row position.
--- @tparam number col Starting column position.
--- @tparam number height Panel height (should be 1).
--- @tparam number width Panel width.
 -- @return nothing
-function Bar:_draw_bar(row, col, height, width)
+function Bar:_draw_bar()
   terminal.output.write(
     terminal.cursor.position.backup_seq(),
-    terminal.cursor.position.set_seq(row, col),
-    self:_build_bar_line(width),
+    terminal.cursor.position.set_seq(self.inner_row, self.inner_col),
+    self:_build_bar_line(self.inner_width),
     terminal.cursor.position.restore_seq()
   )
 end

--- a/src/terminal/ui/panel/init.lua
+++ b/src/terminal/ui/panel/init.lua
@@ -375,7 +375,7 @@ function Panel:render()
     if self.clear_content then
       self:clear()
     end
-    self:content(self.inner_row, self.inner_col, self.inner_height, self.inner_width)
+    self:content()
   else
     -- Render child panels
     for _, child in ipairs(self.children) do


### PR DESCRIPTION
instead of passing position and size, it is now supposed to collect the `inner_xxx` properties