### PR TITLE
Docs: clarify Prompt run() return values and cancellable behavior

### DIFF
--- a/src/terminal/cli/prompt.lua
+++ b/src/terminal/cli/prompt.lua
@@ -250,7 +250,6 @@ end
 --   The final input value entered by the user, or nil if the input was cancelled.
 -- @treturn string
 --   The exit status that terminated the input loop: "returned" or "cancelled".
-
 function Prompt:run()
   local status
 


### PR DESCRIPTION
Clarifies the documented return contract of Prompt:run() and the behavior of the cancellable option so that the documentation matches the existing implementation.

No behavior changes.