### PR TITLE
fix(examples): remove incorrect src prefix in require paths

### DIFF
--- a/examples/tabstrip.lua
+++ b/examples/tabstrip.lua
@@ -2,13 +2,13 @@
 
 -- TabStrip example demonstrating tabbed interface with TabStrip and PanelSet
 
-local TabStrip = require("src.terminal.ui.panel.tab_strip")
-local Set = require("src.terminal.ui.panel.set")
+local TabStrip = require("terminal.ui.panel.tab_strip")
+local Set = require("terminal.ui.panel.set")
 local terminal = require("terminal")
-local Screen = require("src.terminal.ui.panel.screen")
-local Panel = require("src.terminal.ui.panel")
-local Bar = require("src.terminal.ui.panel.bar")
-local TextPanel = require("src.terminal.ui.panel.text")
+local Screen = require("terminal.ui.panel.screen")
+local Panel = require("terminal.ui.panel")
+local Bar = require("terminal.ui.panel.bar")
+local TextPanel = require("terminal.ui.panel.text")
 
 -- Create sample content for each tab
 local tab_contents = {

--- a/examples/text_panel.lua
+++ b/examples/text_panel.lua
@@ -2,12 +2,12 @@
 
 -- TextPanel example demonstrating scrollable text display
 
-local TextPanel = require("src.terminal.ui.panel.text")
+local TextPanel = require("terminal.ui.panel.text")
 local terminal = require("terminal")
-local Screen = require("src.terminal.ui.panel.screen")
-local Panel = require("src.terminal.ui.panel")
-local Bar = require("src.terminal.ui.panel.bar")
-local KeyBar = require("src.terminal.ui.panel.key_bar")
+local Screen = require("terminal.ui.panel.screen")
+local Panel = require("terminal.ui.panel")
+local Bar = require("terminal.ui.panel.bar")
+local KeyBar = require("terminal.ui.panel.key_bar")
 
 -- Create some sample text content
 local sample_text = {


### PR DESCRIPTION
The tabstrip.lua and text_panel.lua examples were using require paths with "src" prefix (e.g., "src.terminal.ui.panel.tab_strip") while all other examples use paths without the prefix (e.g.,
"terminal.ui.panel.tab_strip"). Fixed this.