### PR TITLE
examples: demonstrate exit-key behaviour with coroutine-based focus handling

### DIFF
--- a/examples/prompt_exit_keys_coroutine.lua
+++ b/examples/prompt_exit_keys_coroutine.lua
@@ -79,7 +79,7 @@ local function prompt_loop(initial_value)
       local method = line[action]
       if method then method(line) end
     elseif keytype == "char" and line:len_char() < MAX_LEN and rawkey and #rawkey >= 1 then
-      local ok, err = pcall(function() line:insert(rawkey) end)
+      local ok = pcall(function() line:insert(rawkey) end)
       if not ok then t.bell() end
     else
       t.bell()


### PR DESCRIPTION
@Tieske 
This adds an example demonstrating exit-key behaviour using a coroutine-based approach,
as discussed on Matrix.

The example shows:
- configurable exit keys (Enter, Escape, Tab)
- returning `(value, key)` without enforcing submit/cancel semantics
- focus change via coroutine yield/resume

This PR only adds an example (no library changes) to demonstrate the exit-key + coroutine pattern we discussed: configurable exit keys, returning `(value, key)`, and focus change via `coroutine.yield()`.