### PR TITLE
fix(clear): fix typo in eol_seq() call

### DIFF
--- a/src/terminal/clear.lua
+++ b/src/terminal/clear.lua
@@ -90,7 +90,7 @@ end
 --- Clears from cursor to end of the line (EOL) and writes to the terminal.
 -- @treturn true Always returns true after clearing.
 function M.eol()
-  output.write(M.	eol_seq())
+  output.write(M.eol_seq())
   return true
 end
 


### PR DESCRIPTION
Fixes a typo in `clear.lua` where `M.eol_seq()` was written with an extra space
While the previous version doesn't cause any runtime error but, it breaks method-call consistency and deviates from standard Lua style.

