### PR TITLE
feat(progress): allow ANSI formatting in sprites

### DIFF
--- a/spec/13-progress_spec.lua
+++ b/spec/13-progress_spec.lua
@@ -1,0 +1,86 @@
+local helpers = require "spec.helpers"
+
+
+describe("terminal.progress", function()
+
+  local progress
+  local t
+  local utils
+  local width
+  local color
+
+  local DEFAULT_STEPSIZE = 10
+  local COLORED_SPRITE_CHAR = "█"
+  local DONE_MESSAGE_TEXT = "✓ DONE"
+  local DONE_MESSAGE_CHAR = " "
+  local PLAIN_SPRITE_CHAR = "X"
+
+  setup(function()
+    t = helpers.load()
+    progress = require "terminal.progress"
+    utils = require "terminal.utils"
+    width = require "terminal.text.width"
+    color = require "terminal.text.color"
+  end)
+
+
+  teardown(function()
+    helpers.unload()
+  end)
+
+
+  before_each(function()
+    helpers.clear_output()
+  end)
+
+
+
+  describe("spinner()", function()
+
+    it("uses visible width for colored sprites (ignores ANSI)", function()
+      local red_sprite = color.fore_seq("red") .. COLORED_SPRITE_CHAR
+      local expected_width = width.utf8swidth(utils.strip_ansi(red_sprite))
+      local spinner = progress.spinner({
+        sprites = { [0] = "", red_sprite },
+        stepsize = DEFAULT_STEPSIZE,
+      })
+
+      spinner(false)
+
+      assert.are.equal(red_sprite .. t.cursor.position.left_seq(expected_width), helpers.get_output())
+    end)
+
+
+    it("uses visible width for colored done_sprite", function()
+      local done_sprite = color.fore_seq("green") .. DONE_MESSAGE_TEXT
+      local done_width = width.utf8swidth(utils.strip_ansi(done_sprite))
+      local spinner = progress.spinner({
+        sprites = { [0] = "", DONE_MESSAGE_CHAR },
+        done_sprite = done_sprite,
+        stepsize = DEFAULT_STEPSIZE,
+      })
+
+      spinner(true)
+
+      assert.are.equal(done_sprite .. t.cursor.position.left_seq(done_width), helpers.get_output())
+    end)
+
+
+    it("works correctly for plain sprites without ANSI", function()
+      local spinner = progress.spinner({
+        sprites = { [0] = "", PLAIN_SPRITE_CHAR },
+        stepsize = DEFAULT_STEPSIZE,
+      })
+
+      spinner(false)
+
+      local sprite_width = width.utf8swidth(PLAIN_SPRITE_CHAR)
+      assert.are.equal(
+        PLAIN_SPRITE_CHAR .. t.cursor.position.left_seq(sprite_width),
+        helpers.get_output()
+      )
+    end)
+
+  end)
+
+end)

--- a/src/terminal/progress.lua
+++ b/src/terminal/progress.lua
@@ -108,7 +108,7 @@ function M.spinner(opts)
       local sequence = Sequence()
       sequence[#sequence+1] = pos_set
       sequence[#sequence+1] = (i == 0 and attr_push_done) or attr_push or nil
-      sequence[#sequence+1] = s .. t.cursor.position.left_seq(t.text.width.utf8swidth(s))
+      sequence[#sequence+1] = s .. t.cursor.position.left_seq(tw.utf8swidth(utils.strip_ansi(s)))
       sequence[#sequence+1] = attr_pop
       sequence[#sequence+1] = pos_restore
       steps[i] = sequence


### PR DESCRIPTION
Implements #203.

Spinner and ticker width calculations now ignore ANSI escape sequences
by stripping them before computing visible width. This allows colored
or styled sprites without breaking cursor rewind behavior.

Title rendering was updated to ignore ANSI sequences for width math,
while preserving them when no truncation is required.