### PR TITLE
refactor(tab_strip): improve readability

### DIFF
--- a/spec/27-tab_strip_spec.lua
+++ b/spec/27-tab_strip_spec.lua
@@ -1067,7 +1067,7 @@ describe("terminal.ui.panel.tab_strip", function()
       tab_strip:calculate_layout(1, 1, 1, 20)  -- Small width
       tab_strip:render()
       -- Should have calculated viewport
-      assert.is_not_nil(tab_strip._viewport_offset)
+      assert.is_not_nil(tab_strip._cache.viewport_offset)
     end)
 
 
@@ -1371,7 +1371,7 @@ describe("terminal.ui.panel.tab_strip", function()
       tab_strip:calculate_layout(1, 1, 1, 20)
       tab_strip:render()
       -- Viewport should be adjusted to show selected tab
-      assert.is_not_nil(tab_strip._viewport_offset)
+      assert.is_not_nil(tab_strip._cache.viewport_offset)
     end)
 
 
@@ -1385,7 +1385,7 @@ describe("terminal.ui.panel.tab_strip", function()
       tab_strip:calculate_layout(1, 1, 1, 10)  -- Very small width
       tab_strip:render()
       -- Viewport should be at start of tab
-      assert.are.equal(0, tab_strip._viewport_offset)
+      assert.are.equal(0, tab_strip._cache.viewport_offset)
     end)
 
 
@@ -1400,9 +1400,9 @@ describe("terminal.ui.panel.tab_strip", function()
       tab_strip:calculate_layout(1, 1, 1, 10)
       tab_strip:render()
       -- Should calculate correctly using display width
-      assert.is_not_nil(tab_strip._tab_widths[1])
+      assert.is_not_nil(tab_strip._cache.tab_widths[1])
       -- Double-width characters should be counted as 2 columns
-      assert.is_true(tab_strip._tab_widths[1] >= 2)
+      assert.is_true(tab_strip._cache.tab_widths[1] >= 2)
     end)
 
   end)
@@ -1434,7 +1434,7 @@ describe("terminal.ui.panel.tab_strip", function()
       tab_strip:calculate_layout(1, 1, 1, 20)
       tab_strip:render()
       -- Should calculate widths correctly
-      assert.is_not_nil(tab_strip._tab_widths[1])
+      assert.is_not_nil(tab_strip._cache.tab_widths[1])
     end)
 
 

--- a/spec/27-tab_strip_spec.lua
+++ b/spec/27-tab_strip_spec.lua
@@ -310,15 +310,6 @@ describe("terminal.ui.panel.tab_strip", function()
       assert.is_nil(callback_id)
     end)
 
-
-    it("does not call select_cb when not provided", function()
-      local tab_strip = TabStrip {
-        items = { { label = "Tab 1" } }
-        -- No select_cb provided
-      }
-      assert.is_nil(tab_strip.select_cb)
-    end)
-
   end)
 
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -45,6 +45,19 @@ local default_config = {
 
 
 
+-- Private method to find index of item with given id, or nil.
+-- @return number|nil The index of the item with the given id, or nil if not found.
+function index_by_id(self, id)
+  for i, item in ipairs(self.items) do
+    if item.id == id then
+      return i
+    end
+  end
+  return nil
+end
+
+
+
 -- Validate and process_items
 -- Each item must have a label
 -- If id is missing, use index as id
@@ -69,6 +82,9 @@ end
 
 
 local function validate_option_types(opts)
+  if type(opts) ~= "table" then
+    error("missing argument: options table isn't given, got " .. type(opts))
+  end
   if opts.prefix ~= nil and type(opts.prefix) ~= "string" then
     error("prefix must be a string, got " .. type(opts.prefix))
   end
@@ -113,7 +129,7 @@ end
 -- @tparam[opt=1] number opts.padding Number of spaces between tabs.
 -- @tparam[opt] table opts.attr Text attributes for the entire strip.
 -- @tparam[opt] table opts.selected_attr Text attributes for the selected tab.
--- @tparam[opt] function opts.select_cb Callback function called when selection changes: `select_cb(self, id)`.
+-- @tparam[opt] function opts.select_cb Callback function called when selection changes: `TabStrip:select_cb(id)`.
 -- @treturn TabStrip A new TabStrip instance.
 -- @usage
 --   local TabStrip = require("terminal.ui.panel.tab_strip")
@@ -127,22 +143,17 @@ end
 --     selected_attr = { reverse = true }
 --   }
 function TabStrip:init(opts)
-  if type(opts) ~= "table" then
-    error("missing argument: options table isn't given")
-  end
+  validate_option_types(opts)
 
   -- TabStrip-specific properties (extract before calling parent)
-  local items = opts.items
+  local items = validate_items(opts.items)
   local selected = opts.selected
-  local prefix = opts.prefix
-  local postfix = opts.postfix
-  local padding = opts.padding
+  local prefix = opts.prefix or default_config.prefix
+  local postfix = opts.postfix or default_config.postfix
+  local padding = opts.padding or default_config.padding
   local attr = opts.attr
   local selected_attr = opts.selected_attr
-  local select_cb = opts.select_cb
-
-  -- Validate option types
-  validate_option_types(opts)
+  local select_cb = opts.select_cb or function() end
 
   -- Set fixed height of 1 line
   opts.min_height = MIN_HEIGHT
@@ -165,16 +176,8 @@ function TabStrip:init(opts)
 
   -- Call parent constructor
   Panel.init(self, opts)
-  self.clear_content = default_config.clear_content
-  self._total_content_width = 0
-
-  -- Process and validate items
-  local processed_items = validate_items(items)
-
-  -- Replace empty configurations with defaults
-  prefix = prefix or default_config.prefix
-  postfix = postfix or default_config.postfix
-  padding = padding or default_config.padding
+  self.clear_content = default_config.clear_content -- TODO: is this option useful here?
+  self._total_content_width = 0  -- TODO: remove _ property, can go in _cache?
 
   -- Derive selected_attr from attr if not provided
   if not selected_attr and attr then
@@ -184,33 +187,25 @@ function TabStrip:init(opts)
     end
 
     -- Invert reverse attribute
-    if attr.reverse ~= nil then
-      selected_attr.reverse = not attr.reverse
-    else
-      selected_attr.reverse = true
-    end
+    selected_attr.reverse = not selected_attr.reverse
   end
 
   -- Set TabStrip-specific properties after parent constructor
-  self.items = normalized_items
+  self.items = items
   self.prefix = prefix
   self.postfix = postfix
   self.padding = padding
   self.attr = attr
   self.selected_attr = selected_attr
   self.select_cb = select_cb
+  self.selected = set_selection(items, selected) -- sets default if selected is invalid
 
   -- Viewport management state
   self:_reset_viewport_state()
-  self._viewport_offset = 0
+  self._viewport_offset = 0  -- TODO: remove _ property, can go in _cache?
 
-  -- Handle initial selection
-  self.selected = set_selection(processed_items, selected)
-
-  -- Call select_cb during initialization if provided
-  if self.select_cb then
-    self.select_cb(self, self.selected)
-  end
+  -- Call select_cb during initialization
+  self:select_cb(self.selected)
 end
 
 
@@ -231,14 +226,14 @@ end
 -- Private method to invalidate cache.
 -- @return nothing
 function TabStrip:_invalidate_cache()
-  self._cache_valid = false
+  self._cache_valid = false  -- TODO: remove _ property, can go in _cache?
 end
 
 
 
 -- Private method to reset viewport state.
 -- @return nothing
-function TabStrip:_reset_viewport_state()
+function TabStrip:_reset_viewport_state()  -- TODO: remove _ property, can go in _cache?
   self._tab_widths = {}
   self._tab_positions = {}
   self._total_content_width = 0
@@ -328,9 +323,7 @@ function TabStrip:adjust_viewport_for_selected()
 
   self:_build_cache()
 
-  -- Find selected tab index
-  local selected_index = self:_get_selected_index()
-
+  local selected_index = index_by_id(self, self.selected)
   if not selected_index then
     return
   end
@@ -612,9 +605,7 @@ function TabStrip:select(tab_id)
   end
 
   self.selected = tab_id
-  if self.select_cb then  -- TODO: callabck alwasy set, a NOOp if not provided, to forego on these checks
-    self:select_cb(tab_id)
-  end
+  self:select_cb(tab_id)
 
   return true
 end
@@ -631,16 +622,10 @@ end
 --   end
 function TabStrip:select_next()
   if #self.items == 0 then
-    return self:get_selected()
+    return nil, "no tabs available"
   end
 
-  -- Find current index
-  local current_index = self:_get_selected_index()
-
-  -- If current_index is nil, something went wrong, default to first
-  if not current_index then
-    current_index = 1
-  end
+  local current_index = index_by_id(self, self.selected)
 
   -- Increment index, clamp to last tab
   local next_index = math.min(current_index + 1, #self.items)
@@ -649,9 +634,7 @@ function TabStrip:select_next()
   -- Only update and call callback if selection actually changed
   if self.selected ~= next_id then
     self.selected = next_id
-    if self.select_cb then
-      self.select_cb(self, next_id)
-    end
+    self:select_cb(next_id)
   end
 
   return self:get_selected()
@@ -669,16 +652,10 @@ end
 --   end
 function TabStrip:select_prev()
   if #self.items == 0 then
-    return self:get_selected()
+    return nil, "no tabs available"
   end
 
-  -- Find current index
-  local current_index = self:_get_selected_index()
-
-  -- If current_index is nil, something went wrong, default to first
-  if not current_index then
-    current_index = 1
-  end
+  local current_index = index_by_id(self, self.selected)
 
   -- Decrement index, clamp to first tab
   local prev_index = math.max(current_index - 1, 1)
@@ -687,12 +664,10 @@ function TabStrip:select_prev()
   -- Only update and call callback if selection actually changed
   if self.selected ~= prev_id then
     self.selected = prev_id
-    if self.select_cb then
-      self.select_cb(self, prev_id)
-    end
+    self:select_cb(prev_id)
   end
 
-  return self:get_selected()
+  return self.selected
 end
 
 
@@ -723,28 +698,20 @@ end
 --     { id = "tab2", label = "Tab 2" }
 --   })
 function TabStrip:set_items(items)
-  -- Process and validate items
-  local processed_items = validate_items(items)
+  -- validate items
+  items = validate_items(items)
+  self.items = items
 
-  self.items = processed_items
+  local old_selected = self.selected
   self:_invalidate_cache()
   self.selected = resolve_initial_selection(self.items, old_selected)
 
   -- Adjust selection: validate it still exists, or default to first
-  if #processed_items == 0 then
-    self.selected = nil
+  self.selected = set_selection(items, self.selected)
 
-  else
-    local found = false
-    for _, item in ipairs(processed_items) do
-      if item.id == self.selected then
-        found = true
-        break
-      end
-    end
-    if not found then
-      self.selected = processed_items[1].id
-    end
+  if self.selected ~= old_selected then
+    -- selection changed, so call callback
+    self:select_cb(self.selected)
   end
 end
 
@@ -753,7 +720,7 @@ end
 --- Add a new item to the items list.
 -- @tparam table item The item to add (must have `label` field).
 -- @tparam[opt] any before_id If provided, insert before the item with this id.
--- @return nothing
+-- @return true
 -- @usage
 --   tab_strip:add_item({ id = "tab3", label = "Tab 3" })
 --   tab_strip:add_item({ id = "tab2.5", label = "Tab 2.5" }, "tab3")
@@ -764,25 +731,26 @@ function TabStrip:add_item(item, before_id)
   end
 
   -- Process item with default id if missing
-  local processed_item = {
+  local new_item = {
     id = item.id or (#self.items + 1),
     label = item.label,
   }
 
   if before_id then
-    local insert_index = self:_index_by_id(before_id)
+    local insert_index = index_by_id(self, before_id)
     if insert_index then
-      table.insert(self.items, insert_index, processed_item)
+      table.insert(self.items, insert_index, new_item)
     else
       -- If before_id not found, append to end
-      table.insert(self.items, processed_item)
+      table.insert(self.items, new_item)
     end
   else
     -- Append to end
-    table.insert(self.items, processed_item)
+    table.insert(self.items, new_item)
   end
 
   self:_invalidate_cache()
+  return true
 end
 
 
@@ -794,18 +762,7 @@ end
 -- @usage
 --   local success, err = tab_strip:remove_item("tab2")
 function TabStrip:remove_item(id)
-  -- Find the item to remove
-  local remove_index = nil
-  local was_selected = false
-
-  for i, item in ipairs(self.items) do
-    if item.id == id then
-      remove_index = i
-      was_selected = (item.id == self.selected)
-      break
-    end
-  end
-
+  local remove_index = index_by_id(self, id)
   if not remove_index then
     return nil, "tab id not found"
   end
@@ -815,30 +772,25 @@ function TabStrip:remove_item(id)
   table.remove(self.items, remove_index)
   self:_invalidate_cache()
 
-  -- Adjust selection if needed
-  if was_selected then
-    if #self.items == 0 then
-      -- All tabs removed
-      self.selected = nil
-      if self.select_cb then
-        self.select_cb(self, nil)
-      end
-
-    elseif remove_index == 1 then
-      -- First tab removed, move to new first tab
-      self.selected = self.items[1].id
-      if self.select_cb then
-        self.select_cb(self, self.selected)
-      end
-
-    else
-      -- Move selection to left tab
-      self.selected = self.items[remove_index - 1].id
-      if self.select_cb then
-        self.select_cb(self, self.selected)
-      end
-    end
+  if not was_selected then
+    return true  -- No change to selection, so we're done
   end
+
+  -- selected tab was removed, need to update selection
+  if #self.items == 0 then
+    -- No tabs left, clear selection
+    self.selected = nil
+
+  elseif remove_index == 1 then
+    -- First tab removed, move to new first tab
+    self.selected = self.items[1].id
+
+  else
+    -- Move selection one to the left
+    self.selected = self.items[remove_index - 1].id
+  end
+
+  self:select_cb(self.selected)
 
   return true
 end

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -290,6 +290,61 @@ end
 
 
 
+local function adjust_viewport_for_selected(self)
+  if not self.selected then
+    return
+  end
+
+  local cache = get_cache(self)
+
+  local selected_index = index_by_id(self, self.selected)
+  if not selected_index then
+    return
+  end
+
+  -- Calculate effective width (accounting for overflow indicators)
+  local effective_width = self.inner_width
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
+
+  if cache.total_content_width > self.inner_width then
+    -- Need overflow indicators
+    effective_width = self.inner_width - (ellipsis_width * 2)
+  end
+
+  -- Get selected tab position and width
+  local tab_start = cache.tab_positions[selected_index]
+  local tab_width = cache.tab_widths[selected_index]
+  local tab_end = tab_start + tab_width
+
+  -- Adjust viewport to show selected tab
+  if tab_start < cache.viewport_offset then
+    -- Tab is to the left of viewport, move viewport to show it
+    cache.viewport_offset = tab_start
+
+  elseif tab_end > cache.viewport_offset + effective_width then
+    -- Tab is to the right of viewport, move viewport to show it
+    if tab_width > effective_width then
+      -- Tab is wider than effective width, left-justify it
+      cache.viewport_offset = tab_start
+
+    else
+      -- Show tab at the right edge
+      cache.viewport_offset = tab_end - effective_width
+    end
+  end
+
+  -- Clamp viewport offset
+  if cache.viewport_offset < 0 then
+    cache.viewport_offset = 0
+  end
+  local max_offset = math.max(0, cache.total_content_width - effective_width)
+  if cache.viewport_offset > max_offset then
+    cache.viewport_offset = max_offset
+  end
+end
+
+
+
 -- Private method to build the tab line sequence.
 -- @tparam number available_width Available width for the tab strip.
 -- @treturn Sequence The complete tab line sequence.
@@ -313,7 +368,7 @@ local function build_tab_line(self, available_width)
   end
 
   -- Adjust viewport to show selected tab
-  self:adjust_viewport_for_selected()
+  adjust_viewport_for_selected(self)
 
   -- Calculate effective width and overflow indicators
   local has_left_overflow, has_right_overflow, effective_width =
@@ -447,61 +502,6 @@ function TabStrip:init(opts)
 
   -- Call select_cb during initialization
   self:select_cb(self.selected)
-end
-
-
-
-function TabStrip:adjust_viewport_for_selected()
-  if not self.selected then
-    return
-  end
-
-  local cache = get_cache(self)
-
-  local selected_index = index_by_id(self, self.selected)
-  if not selected_index then
-    return
-  end
-
-  -- Calculate effective width (accounting for overflow indicators)
-  local effective_width = self.inner_width
-  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
-
-  if cache.total_content_width > self.inner_width then
-    -- Need overflow indicators
-    effective_width = self.inner_width - (ellipsis_width * 2)
-  end
-
-  -- Get selected tab position and width
-  local tab_start = cache.tab_positions[selected_index]
-  local tab_width = cache.tab_widths[selected_index]
-  local tab_end = tab_start + tab_width
-
-  -- Adjust viewport to show selected tab
-  if tab_start < cache.viewport_offset then
-    -- Tab is to the left of viewport, move viewport to show it
-    cache.viewport_offset = tab_start
-
-  elseif tab_end > cache.viewport_offset + effective_width then
-    -- Tab is to the right of viewport, move viewport to show it
-    if tab_width > effective_width then
-      -- Tab is wider than effective width, left-justify it
-      cache.viewport_offset = tab_start
-
-    else
-      -- Show tab at the right edge
-      cache.viewport_offset = tab_end - effective_width
-    end
-  end
-
-  -- Clamp viewport offset
-  if cache.viewport_offset < 0 then
-    cache.viewport_offset = 0
-  end
-  local max_offset = math.max(0, cache.total_content_width - effective_width)
-  if cache.viewport_offset > max_offset then
-    cache.viewport_offset = max_offset
-  end
 end
 
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -47,7 +47,7 @@ local default_config = {
 
 -- Private method to find index of item with given id, or nil.
 -- @return number|nil The index of the item with the given id, or nil if not found.
-function index_by_id(self, id)
+local function index_by_id(self, id)
   for i, item in ipairs(self.items) do
     if item.id == id then
       return i
@@ -177,7 +177,6 @@ function TabStrip:init(opts)
   -- Call parent constructor
   Panel.init(self, opts)
   self.clear_content = default_config.clear_content -- TODO: is this option useful here?
-  self._total_content_width = 0  -- TODO: remove _ property, can go in _cache?
 
   -- Derive selected_attr from attr if not provided
   if not selected_attr and attr then
@@ -201,8 +200,7 @@ function TabStrip:init(opts)
   self.selected = set_selection(items, selected) -- sets default if selected is invalid
 
   -- Viewport management state
-  self:_reset_viewport_state()
-  self._viewport_offset = 0  -- TODO: remove _ property, can go in _cache?
+  self:_invalidate_cache()
 
   -- Call select_cb during initialization
   self:select_cb(self.selected)
@@ -226,34 +224,22 @@ end
 -- Private method to invalidate cache.
 -- @return nothing
 function TabStrip:_invalidate_cache()
-  self._cache_valid = false  -- TODO: remove _ property, can go in _cache?
+  self._cache = nil
 end
 
 
 
--- Private method to reset viewport state.
--- @return nothing
-function TabStrip:_reset_viewport_state()  -- TODO: remove _ property, can go in _cache?
-  self._tab_widths = {}
-  self._tab_positions = {}
-  self._total_content_width = 0
-end
-
-
-
--- Private method to build cache of tab widths and positions.
--- @return nothing
-function TabStrip:_build_cache()
-  if self._cache_valid then
-    return
+-- Private method to get (and build) cache of tab widths and positions.
+-- @return cache
+function TabStrip:_get_cache()
+  if not self._cache then
+    self._cache = {
+      viewport_offset = 0,
+    }
+    self:_calculate_total_content_width()
   end
 
-  self:_reset_viewport_state()
-
-  -- Calculate total content width and populate tab widths and positions
-  self:_calculate_total_content_width()
-
-  self._cache_valid = true
+  return self._cache
 end
 
 
@@ -261,22 +247,33 @@ end
 -- Private method to calculate total content width.
 -- @treturn number Total width of all tabs including padding.
 function TabStrip:_calculate_total_content_width()
+  local cache = self:_get_cache()
+  local total_content_width = 0
+  local tab_widths = {}
+  cache.tab_widths = tab_widths
+  local tab_positions = {}
+  cache.tab_positions = tab_positions
+
+  local pre_width = width.utf8swidth(self.prefix)
+  local post_width = width.utf8swidth(self.postfix)
+
   for i, item in ipairs(self.items) do
     -- Format tab: prefix + label + postfix
-    local tab_text = self.prefix .. item.label .. self.postfix
-    local tab_width = width.utf8swidth(tab_text)
+    local tab_width = pre_width + width.utf8swidth(item.label) + post_width
 
-    self._tab_widths[i] = tab_width
-    self._tab_positions[i] = self._total_content_width
+    tab_widths[i] = tab_width
+    tab_positions[i] = total_content_width
 
-    -- Add tab width
-    self._total_content_width = self._total_content_width + tab_width
-
-    -- Add padding (except after last tab)
-    if i < #self.items then
-      self._total_content_width = self._total_content_width + self.padding
-    end
+    -- Add tab width and padding
+    total_content_width = total_content_width + tab_width + self.padding
   end
+
+  -- remove final padding (if there are any tabs)
+  if self.items[1] then
+    total_content_width = total_content_width - self.padding
+  end
+
+  cache.total_content_width = total_content_width
 end
 
 
@@ -291,24 +288,26 @@ function TabStrip:_calculate_total_content_width_and_overflow(available_width)
   local has_right_overflow = false
   local effective_width = available_width
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
+  local cache = self:_get_cache()
+  local total_content_width = cache.total_content_width
 
-  if self._total_content_width > available_width then
+  if cache.total_content_width > available_width then
     -- Need overflow indicators
     effective_width = available_width - (ellipsis_width * 2)
-    has_left_overflow = (self._viewport_offset > 0)
-    has_right_overflow = (self._viewport_offset + effective_width < self._total_content_width)
+    has_left_overflow = (cache.viewport_offset > 0)
+    has_right_overflow = (cache.viewport_offset + effective_width < total_content_width)
   end
 
   -- Adjust effective width if only one indicator is needed
   if has_left_overflow and not has_right_overflow then
     effective_width = available_width - ellipsis_width
     -- Recalculate has_right_overflow with adjusted effective_width for consistency
-    has_right_overflow = (self._viewport_offset + effective_width < self._total_content_width)
+    has_right_overflow = (cache.viewport_offset + effective_width < total_content_width)
 
   elseif has_right_overflow and not has_left_overflow then
     effective_width = available_width - ellipsis_width
     -- Recalculate has_right_overflow with adjusted effective_width for consistency
-    has_right_overflow = (self._viewport_offset + effective_width < self._total_content_width)
+    has_right_overflow = (cache.viewport_offset + effective_width < total_content_width)
   end
 
   return has_left_overflow, has_right_overflow, effective_width
@@ -317,11 +316,11 @@ end
 
 
 function TabStrip:adjust_viewport_for_selected()
-  if #self.items == 0 or not self.selected then
+  if not self.selected then
     return
   end
 
-  self:_build_cache()
+  local cache = self:_get_cache()
 
   local selected_index = index_by_id(self, self.selected)
   if not selected_index then
@@ -332,40 +331,40 @@ function TabStrip:adjust_viewport_for_selected()
   local effective_width = self.inner_width
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
-  if self._total_content_width > self.inner_width then
+  if cache.total_content_width > self.inner_width then
     -- Need overflow indicators
     effective_width = self.inner_width - (ellipsis_width * 2)
   end
 
   -- Get selected tab position and width
-  local tab_start = self._tab_positions[selected_index]
-  local tab_width = self._tab_widths[selected_index]
+  local tab_start = cache.tab_positions[selected_index]
+  local tab_width = cache.tab_widths[selected_index]
   local tab_end = tab_start + tab_width
 
   -- Adjust viewport to show selected tab
-  if tab_start < self._viewport_offset then
+  if tab_start < cache.viewport_offset then
     -- Tab is to the left of viewport, move viewport to show it
-    self._viewport_offset = tab_start
+    cache.viewport_offset = tab_start
 
-  elseif tab_end > self._viewport_offset + effective_width then
+  elseif tab_end > cache.viewport_offset + effective_width then
     -- Tab is to the right of viewport, move viewport to show it
     if tab_width > effective_width then
       -- Tab is wider than effective width, left-justify it
-      self._viewport_offset = tab_start
+      cache.viewport_offset = tab_start
 
     else
       -- Show tab at the right edge
-      self._viewport_offset = tab_end - effective_width
+      cache.viewport_offset = tab_end - effective_width
     end
   end
 
   -- Clamp viewport offset
-  if self._viewport_offset < 0 then
-    self._viewport_offset = 0
+  if cache.viewport_offset < 0 then
+    cache.viewport_offset = 0
   end
-  local max_offset = math.max(0, self._total_content_width - effective_width)
-  if self._viewport_offset > max_offset then
-    self._viewport_offset = max_offset
+  local max_offset = math.max(0, cache.total_content_width - effective_width)
+  if cache.viewport_offset > max_offset then
+    cache.viewport_offset = max_offset
   end
 end
 
@@ -392,9 +391,6 @@ function TabStrip:_build_tab_line(available_width)
     end
     return s
   end
-
-  -- Build cache
-  self:_build_cache()
 
   -- Adjust viewport to show selected tab
   self:adjust_viewport_for_selected()
@@ -441,14 +437,15 @@ end
 -- @return number The total width of the rendered content (excluding overflow indicators).
 function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
-  local visible_start = self._viewport_offset
-  local visible_end = visible_start + effective_width
   local rendered_width = has_left_overflow and ellipsis_width or 0
+  local cache = self:_get_cache()
+  local visible_start = cache.viewport_offset
+  local visible_end = visible_start + effective_width
 
   for i, item in ipairs(self.items) do
     local tab_text = self.prefix .. item.label .. self.postfix
-    local tab_start = self._tab_positions[i]
-    local tab_end = tab_start + self._tab_widths[i]
+    local tab_start = cache.tab_positions[i]
+    local tab_end = tab_start + cache.tab_widths[i]
 
     -- Check if this tab is visible
     if tab_end > visible_start and tab_start < visible_end then
@@ -456,7 +453,7 @@ function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
 
       -- Calculate what portion of this tab is visible
       local tab_visible_start_col = math.max(0, visible_start - tab_start)
-      local tab_visible_end_col = math.min(self._tab_widths[i], visible_end - tab_start)
+      local tab_visible_end_col = math.min(cache.tab_widths[i], visible_end - tab_start)
 
       if tab_visible_end_col > tab_visible_start_col then
         -- Extract visible portion of tab

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -27,10 +27,6 @@ local output = terminal.output
 
 
 
-local TabStrip = utils.class(Panel)
-
-
-
 local default_config = {
   prefix = "[",
   postfix = "]",
@@ -414,6 +410,11 @@ local function draw_tabs(self)
     cursor_pos.restore_seq()
   )
 end
+
+
+
+-- TabStrip class definition
+local TabStrip = utils.class(Panel)
 
 
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -45,18 +45,19 @@ local default_config = {
 
 
 
+-- Validate and process_items
+-- Each item must have a label
+-- If id is missing, use index as id
 local function validate_items(items)
     items = items or {}
 
     local processed_items = {}
 
     for i, item in ipairs(items) do
-        -- Validate item has required label field
         if not item.label then
             error("Tab item must have 'label' field, at index(" .. tostring(i) .. ")")
         end
 
-        -- Create processed item with default id if missing
         processed_items[i] = {
             id = item.id or i,
             label = item.label
@@ -85,18 +86,6 @@ end
 
 
 
-local function filter(t, predicate)
-  local result = {}
-  for _, v in ipairs(t) do
-    if predicate(v) then
-      table.insert(result, v)
-    end
-  end
-  return result
-end
-
-
-
 function TabStrip:_handle_initial_selection(items, selected)
   for _, item in ipairs(items) do
     if item.id == selected then
@@ -106,7 +95,7 @@ function TabStrip:_handle_initial_selection(items, selected)
   end
 
   -- not found, pick first item, or nil if no items
-  self.selected = (items[1] or {}).id 
+  self.selected = (items[1] or {}).id
 end
 
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -201,7 +201,7 @@ function TabStrip:init(opts)
   self.selected = selection(items, selected) -- sets default if selected is invalid
 
   -- Viewport management state
-  self:_invalidate_cache()
+  self:_clear_cache()
 
   -- Call select_cb during initialization
   self:select_cb(self.selected)
@@ -224,7 +224,7 @@ end
 
 -- Private method to invalidate cache.
 -- @return nothing
-function TabStrip:_invalidate_cache()
+function TabStrip:_clear_cache()
   self._cache = nil
 end
 
@@ -701,8 +701,7 @@ function TabStrip:set_items(items)
   self.items = items
 
   local old_selected = self.selected
-  self:_invalidate_cache()
-  self.selected = resolve_initial_selection(self.items, old_selected)
+  self:_clear_cache()
 
   -- Adjust selection: validate it still exists, or default to first
   self.selected = selection(items, self.selected)
@@ -747,7 +746,7 @@ function TabStrip:add_item(item, before_id)
     table.insert(self.items, new_item)
   end
 
-  self:_invalidate_cache()
+  self:_clear_cache()
   return true
 end
 
@@ -768,7 +767,7 @@ function TabStrip:remove_item(id)
   local was_selected = (self.selected == id)
 
   table.remove(self.items, remove_index)
-  self:_invalidate_cache()
+  self:_clear_cache()
 
   if not was_selected then
     return true  -- No change to selection, so we're done

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -58,9 +58,9 @@ end
 
 
 
--- Validate and process_items
+-- Validate items
 -- Each item must have a label
--- If id is missing, use index as id
+-- If id is missing, will set index as id
 local function validate_items(items)
   items = items or {}
   local processed_items = {}
@@ -81,6 +81,7 @@ end
 
 
 
+-- validate the options when createing a new instance, throw error if invalid
 local function validate_option_types(opts)
   if type(opts) ~= "table" then
     error("missing argument: options table isn't given, got " .. type(opts))
@@ -106,7 +107,7 @@ end
 -- @tparam table items The array of tab items
 -- @tparam any selected The selected tab ID to validate
 -- @return any|nil The validated selected tab ID. If not found, 1st entry, or nil if there are no items.
-local function set_selection(items, selected)
+local function selection(items, selected)
   for _, item in ipairs(items) do
     if item.id == selected then
       return selected
@@ -197,7 +198,7 @@ function TabStrip:init(opts)
   self.attr = attr
   self.selected_attr = selected_attr
   self.select_cb = select_cb
-  self.selected = set_selection(items, selected) -- sets default if selected is invalid
+  self.selected = selection(items, selected) -- sets default if selected is invalid
 
   -- Viewport management state
   self:_invalidate_cache()
@@ -591,7 +592,7 @@ end
 --     print("Error:", err)
 --   end
 function TabStrip:select(tab_id)
-  local new_selection = set_selection(self.items, tab_id)
+  local new_selection = selection(self.items, tab_id)
 
   if new_selection ~= tab_id then
     return nil, "tab id not found: '" .. tostring(tab_id) .. "'"
@@ -704,7 +705,7 @@ function TabStrip:set_items(items)
   self.selected = resolve_initial_selection(self.items, old_selected)
 
   -- Adjust selection: validate it still exists, or default to first
-  self.selected = set_selection(items, self.selected)
+  self.selected = selection(items, self.selected)
 
   if self.selected ~= old_selected then
     -- selection changed, so call callback

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -120,124 +120,19 @@ end
 
 
 
---- Create a new TabStrip instance.
--- Do not call this method directly, call on the class instead.
--- @tparam table opts Configuration options (see `Panel:init` for inherited properties)
--- @tparam table opts.items Array of tab items, each with `label` field (required) and optional `id` field.
--- @tparam[opt] any opts.selected Initial selected tab id.
--- @tparam[opt="["] string opts.prefix Prefix string for tab labels.
--- @tparam[opt="["] string opts.postfix Postfix string for tab labels.
--- @tparam[opt=1] number opts.padding Number of spaces between tabs.
--- @tparam[opt] table opts.attr Text attributes for the entire strip.
--- @tparam[opt] table opts.selected_attr Text attributes for the selected tab.
--- @tparam[opt] function opts.select_cb Callback function called when selection changes: `TabStrip:select_cb(id)`.
--- @treturn TabStrip A new TabStrip instance.
--- @usage
---   local TabStrip = require("terminal.ui.panel.tab_strip")
---   local tab_strip = TabStrip {
---     items = {
---       { id = "tab1", label = "Tab 1" },
---       { id = "tab2", label = "Tab 2" }
---     },
---     selected = "tab1",
---     attr = { fg = "white", bg = "black" },
---     selected_attr = { reverse = true }
---   }
-function TabStrip:init(opts)
-  validate_option_types(opts)
-
-  -- TabStrip-specific properties (extract before calling parent)
-  local items = validate_items(opts.items)
-  local selected = opts.selected
-  local prefix = opts.prefix or default_config.prefix
-  local postfix = opts.postfix or default_config.postfix
-  local padding = opts.padding or default_config.padding
-  local attr = opts.attr
-  local selected_attr = opts.selected_attr
-  local select_cb = opts.select_cb or function() end
-
-  -- Set fixed height of 1 line
-  opts.min_height = MIN_HEIGHT
-  opts.max_height = MAX_HEIGHT
-
-  -- Provide content callback for parent constructor
-  opts.content = function(self)
-    self:_draw_tabs()
-  end
-
-  -- Remove TabStrip-specific options from opts to avoid conflicts with Panel
-  opts.items = nil
-  opts.selected = nil
-  opts.prefix = nil
-  opts.postfix = nil
-  opts.padding = nil
-  opts.attr = nil
-  opts.selected_attr = nil
-  opts.select_cb = nil
-
-  -- Call parent constructor
-  Panel.init(self, opts)
-  self.clear_content = default_config.clear_content -- TODO: is this option useful here?
-
-  -- Derive selected_attr from attr if not provided
-  if not selected_attr and attr then
-    selected_attr = {}
-    for k, v in pairs(attr) do
-      selected_attr[k] = v
-    end
-
-    -- Invert reverse attribute
-    selected_attr.reverse = not selected_attr.reverse
-  end
-
-  -- Set TabStrip-specific properties after parent constructor
-  self.items = items
-  self.prefix = prefix
-  self.postfix = postfix
-  self.padding = padding
-  self.attr = attr
-  self.selected_attr = selected_attr
-  self.select_cb = select_cb
-  self.selected = selection(items, selected) -- sets default if selected is invalid
-
-  -- Viewport management state
-  self:_clear_cache()
-
-  -- Call select_cb during initialization
-  self:select_cb(self.selected)
-end
-
-
-
--- Private method to draw the tab strip content.
--- @return nothing
-function TabStrip:_draw_tabs()
-  output.write(
-    cursor_pos.backup_seq(),
-    cursor_pos.set_seq(self.inner_row, self.inner_col),
-    self:_build_tab_line(self.inner_width),
-    cursor_pos.restore_seq()
-  )
-end
-
-
-
--- Private method to invalidate cache.
--- @return nothing
-function TabStrip:_clear_cache()
-  self._cache = nil
-end
+-- forward declaration needed for mutual recursion between get_cache and calculate_total_content_width
+local calculate_total_content_width
 
 
 
 -- Private method to get (and build) cache of tab widths and positions.
 -- @return cache
-function TabStrip:_get_cache()
+local function get_cache(self)
   if not self._cache then
     self._cache = {
       viewport_offset = 0,
     }
-    self:_calculate_total_content_width()
+    calculate_total_content_width(self)
   end
 
   return self._cache
@@ -247,8 +142,8 @@ end
 
 -- Private method to calculate total content width.
 -- @treturn number Total width of all tabs including padding.
-function TabStrip:_calculate_total_content_width()
-  local cache = self:_get_cache()
+calculate_total_content_width = function(self)
+  local cache = get_cache(self)
   local total_content_width = 0
   local tab_widths = {}
   cache.tab_widths = tab_widths
@@ -279,17 +174,25 @@ end
 
 
 
+-- Private method to invalidate cache.
+-- @return nothing
+local function clear_cache(self)
+  self._cache = nil
+end
+
+
+
 -- Private method to calculate effective width and overflow indicators.
 -- @tparam number available_width Available width for the tab strip.
 -- @treturn boolean has_left_overflow Whether there is overflow to the left.
 -- @treturn boolean has_right_overflow Whether there is overflow to the right.
 -- @treturn number effective_width The width available for rendering tabs after accounting for overflow indicators.
-function TabStrip:_calculate_total_content_width_and_overflow(available_width)
+local function calculate_total_content_width_and_overflow(self, available_width)
   local has_left_overflow = false
   local has_right_overflow = false
   local effective_width = available_width
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
-  local cache = self:_get_cache()
+  local cache = get_cache(self)
   local total_content_width = cache.total_content_width
 
   if cache.total_content_width > available_width then
@@ -316,130 +219,16 @@ end
 
 
 
-function TabStrip:adjust_viewport_for_selected()
-  if not self.selected then
-    return
-  end
-
-  local cache = self:_get_cache()
-
-  local selected_index = index_by_id(self, self.selected)
-  if not selected_index then
-    return
-  end
-
-  -- Calculate effective width (accounting for overflow indicators)
-  local effective_width = self.inner_width
-  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
-
-  if cache.total_content_width > self.inner_width then
-    -- Need overflow indicators
-    effective_width = self.inner_width - (ellipsis_width * 2)
-  end
-
-  -- Get selected tab position and width
-  local tab_start = cache.tab_positions[selected_index]
-  local tab_width = cache.tab_widths[selected_index]
-  local tab_end = tab_start + tab_width
-
-  -- Adjust viewport to show selected tab
-  if tab_start < cache.viewport_offset then
-    -- Tab is to the left of viewport, move viewport to show it
-    cache.viewport_offset = tab_start
-
-  elseif tab_end > cache.viewport_offset + effective_width then
-    -- Tab is to the right of viewport, move viewport to show it
-    if tab_width > effective_width then
-      -- Tab is wider than effective width, left-justify it
-      cache.viewport_offset = tab_start
-
-    else
-      -- Show tab at the right edge
-      cache.viewport_offset = tab_end - effective_width
-    end
-  end
-
-  -- Clamp viewport offset
-  if cache.viewport_offset < 0 then
-    cache.viewport_offset = 0
-  end
-  local max_offset = math.max(0, cache.total_content_width - effective_width)
-  if cache.viewport_offset > max_offset then
-    cache.viewport_offset = max_offset
-  end
-end
-
-
-
--- Private method to build the tab line sequence.
--- @tparam number available_width Available width for the tab strip.
--- @treturn Sequence The complete tab line sequence.
-function TabStrip:_build_tab_line(available_width)
-  local s = Sequence()
-
-  -- Apply global attr if specified
-  if self.attr then
-    s[#s + 1] = function()
-      return text.push_seq(self.attr)
-    end
-  end
-
-  -- Handle empty items
-  if #self.items == 0 then
-    s[#s+1] = string.rep(" ", available_width)
-    if self.attr then
-      s[#s+1] = text.pop_seq
-    end
-    return s
-  end
-
-  -- Adjust viewport to show selected tab
-  self:adjust_viewport_for_selected()
-
-  -- Calculate effective width and overflow indicators
-  local has_left_overflow, has_right_overflow, effective_width =
-    self:_calculate_total_content_width_and_overflow(available_width)
-  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
-
-  -- Build output with overflow indicators
-  if has_left_overflow then
-    s[#s+1] = default_config.ellipsis
-  end
-
-  -- Render visible content with attributes
-  local rendered_width = self:_render_visible_content(s, effective_width, has_left_overflow)
-
-  if has_right_overflow then
-    s[#s+1] = default_config.ellipsis
-    rendered_width = rendered_width + ellipsis_width
-  end
-
-  -- Fill remaining width with spaces
-  local remaining = available_width - rendered_width
-  if remaining > 0 then
-    s[#s+1] = string.rep(" ", remaining)
-  end
-
-  -- Pop global attr if specified
-  if self.attr then
-    s[#s+1] = text.pop_seq
-  end
-
-  return s
-end
-
-
-
 -- Private method to render the tab line sequence based on current viewport.
 -- @tparam Sequence s The sequence to append to.
 -- @tparam number effective_width The width available for rendering tabs after accounting for overflow indicators.
 -- @tparam boolean has_left_overflow Whether there is overflow to the left (used to determine
 -- if we need to start with an ellipsis).
 -- @return number The total width of the rendered content (excluding overflow indicators).
-function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
+local function render_visible_content(self, s, effective_width, has_left_overflow)
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
   local rendered_width = has_left_overflow and ellipsis_width or 0
-  local cache = self:_get_cache()
+  local cache = get_cache(self)
   local visible_start = cache.viewport_offset
   local visible_end = visible_start + effective_width
 
@@ -504,7 +293,7 @@ end
 -- Private method to build the tab line sequence.
 -- @tparam number available_width Available width for the tab strip.
 -- @treturn Sequence The complete tab line sequence.
-function TabStrip:_build_tab_line(available_width)
+local function build_tab_line(self, available_width)
   local s = Sequence()
 
   -- Apply global attr if specified
@@ -523,15 +312,12 @@ function TabStrip:_build_tab_line(available_width)
     return s
   end
 
-  -- Build cache
-  self:_build_cache()
-
   -- Adjust viewport to show selected tab
-  self:_adjust_viewport_for_selected()
+  self:adjust_viewport_for_selected()
 
   -- Calculate effective width and overflow indicators
   local has_left_overflow, has_right_overflow, effective_width =
-    self:_calculate_total_content_width_and_overflow(available_width)
+    calculate_total_content_width_and_overflow(self, available_width)
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
   -- Build output with overflow indicators
@@ -540,7 +326,7 @@ function TabStrip:_build_tab_line(available_width)
   end
 
   -- Render visible content with attributes
-  local rendered_width = self:_render_visible_content(s, effective_width, has_left_overflow)
+  local rendered_width = render_visible_content(self, s, effective_width, has_left_overflow)
 
   if has_right_overflow then
     s[#s+1] = default_config.ellipsis
@@ -559,6 +345,163 @@ function TabStrip:_build_tab_line(available_width)
   end
 
   return s
+end
+
+
+
+-- Private method to draw the tab strip content.
+-- @return nothing
+local function draw_tabs(self)
+  output.write(
+    cursor_pos.backup_seq(),
+    cursor_pos.set_seq(self.inner_row, self.inner_col),
+    build_tab_line(self, self.inner_width),
+    cursor_pos.restore_seq()
+  )
+end
+
+
+
+--- Create a new TabStrip instance.
+-- Do not call this method directly, call on the class instead.
+-- @tparam table opts Configuration options (see `Panel:init` for inherited properties)
+-- @tparam table opts.items Array of tab items, each with `label` field (required) and optional `id` field.
+-- @tparam[opt] any opts.selected Initial selected tab id.
+-- @tparam[opt="["] string opts.prefix Prefix string for tab labels.
+-- @tparam[opt="["] string opts.postfix Postfix string for tab labels.
+-- @tparam[opt=1] number opts.padding Number of spaces between tabs.
+-- @tparam[opt] table opts.attr Text attributes for the entire strip.
+-- @tparam[opt] table opts.selected_attr Text attributes for the selected tab.
+-- @tparam[opt] function opts.select_cb Callback function called when selection changes: `TabStrip:select_cb(id)`.
+-- @treturn TabStrip A new TabStrip instance.
+-- @usage
+--   local TabStrip = require("terminal.ui.panel.tab_strip")
+--   local tab_strip = TabStrip {
+--     items = {
+--       { id = "tab1", label = "Tab 1" },
+--       { id = "tab2", label = "Tab 2" }
+--     },
+--     selected = "tab1",
+--     attr = { fg = "white", bg = "black" },
+--     selected_attr = { reverse = true }
+--   }
+function TabStrip:init(opts)
+  validate_option_types(opts)
+
+  -- TabStrip-specific properties (extract before calling parent)
+  local items = validate_items(opts.items)
+  local selected = opts.selected
+  local prefix = opts.prefix or default_config.prefix
+  local postfix = opts.postfix or default_config.postfix
+  local padding = opts.padding or default_config.padding
+  local attr = opts.attr
+  local selected_attr = opts.selected_attr
+  local select_cb = opts.select_cb or function() end
+
+  -- Set fixed height of 1 line
+  opts.min_height = MIN_HEIGHT
+  opts.max_height = MAX_HEIGHT
+
+  -- Provide content callback for parent constructor
+  opts.content = function(self)
+    draw_tabs(self)
+  end
+
+  -- Remove TabStrip-specific options from opts to avoid conflicts with Panel
+  opts.items = nil
+  opts.selected = nil
+  opts.prefix = nil
+  opts.postfix = nil
+  opts.padding = nil
+  opts.attr = nil
+  opts.selected_attr = nil
+  opts.select_cb = nil
+
+  -- Call parent constructor
+  Panel.init(self, opts)
+  self.clear_content = default_config.clear_content -- TODO: is this option useful here?
+
+  -- Derive selected_attr from attr if not provided
+  if not selected_attr and attr then
+    selected_attr = {}
+    for k, v in pairs(attr) do
+      selected_attr[k] = v
+    end
+
+    -- Invert reverse attribute
+    selected_attr.reverse = not selected_attr.reverse
+  end
+
+  -- Set TabStrip-specific properties after parent constructor
+  self.items = items
+  self.prefix = prefix
+  self.postfix = postfix
+  self.padding = padding
+  self.attr = attr
+  self.selected_attr = selected_attr
+  self.select_cb = select_cb
+  self.selected = selection(items, selected) -- sets default if selected is invalid
+
+  -- Viewport management state
+  clear_cache(self)
+
+  -- Call select_cb during initialization
+  self:select_cb(self.selected)
+end
+
+
+
+function TabStrip:adjust_viewport_for_selected()
+  if not self.selected then
+    return
+  end
+
+  local cache = get_cache(self)
+
+  local selected_index = index_by_id(self, self.selected)
+  if not selected_index then
+    return
+  end
+
+  -- Calculate effective width (accounting for overflow indicators)
+  local effective_width = self.inner_width
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
+
+  if cache.total_content_width > self.inner_width then
+    -- Need overflow indicators
+    effective_width = self.inner_width - (ellipsis_width * 2)
+  end
+
+  -- Get selected tab position and width
+  local tab_start = cache.tab_positions[selected_index]
+  local tab_width = cache.tab_widths[selected_index]
+  local tab_end = tab_start + tab_width
+
+  -- Adjust viewport to show selected tab
+  if tab_start < cache.viewport_offset then
+    -- Tab is to the left of viewport, move viewport to show it
+    cache.viewport_offset = tab_start
+
+  elseif tab_end > cache.viewport_offset + effective_width then
+    -- Tab is to the right of viewport, move viewport to show it
+    if tab_width > effective_width then
+      -- Tab is wider than effective width, left-justify it
+      cache.viewport_offset = tab_start
+
+    else
+      -- Show tab at the right edge
+      cache.viewport_offset = tab_end - effective_width
+    end
+  end
+
+  -- Clamp viewport offset
+  if cache.viewport_offset < 0 then
+    cache.viewport_offset = 0
+  end
+  local max_offset = math.max(0, cache.total_content_width - effective_width)
+  if cache.viewport_offset > max_offset then
+    cache.viewport_offset = max_offset
+  end
 end
 
 
@@ -701,7 +644,7 @@ function TabStrip:set_items(items)
   self.items = items
 
   local old_selected = self.selected
-  self:_clear_cache()
+  clear_cache(self)
 
   -- Adjust selection: validate it still exists, or default to first
   self.selected = selection(items, self.selected)
@@ -746,7 +689,7 @@ function TabStrip:add_item(item, before_id)
     table.insert(self.items, new_item)
   end
 
-  self:_clear_cache()
+  clear_cache(self)
   return true
 end
 
@@ -767,7 +710,7 @@ function TabStrip:remove_item(id)
   local was_selected = (self.selected == id)
 
   table.remove(self.items, remove_index)
-  self:_clear_cache()
+  clear_cache(self)
 
   if not was_selected then
     return true  -- No change to selection, so we're done

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -32,11 +32,11 @@ local TabStrip = utils.class(Panel)
 
 
 local default_config = {
-    prefix = "[",
-    postfix = "]",
-    clear_content = false,
-    ellipsis = "…",
-    padding = 1
+  prefix = "[",
+  postfix = "]",
+  clear_content = false,
+  ellipsis = "…",
+  padding = 1,
 }
 
 
@@ -49,22 +49,22 @@ local default_config = {
 -- Each item must have a label
 -- If id is missing, use index as id
 local function validate_items(items)
-    items = items or {}
+  items = items or {}
 
-    local processed_items = {}
+  local processed_items = {}
 
-    for i, item in ipairs(items) do
-        if not item.label then
-            error("Tab item must have 'label' field, at index(" .. tostring(i) .. ")")
-        end
-
-        processed_items[i] = {
-            id = item.id or i,
-            label = item.label
-        }
+  for i, item in ipairs(items) do
+    if not item.label then
+      error("Tab item must have 'label' field, at index(" .. tostring(i) .. ")")
     end
 
-    return processed_items
+    processed_items[i] = {
+      id = item.id or i,
+      label = item.label,
+    }
+  end
+
+  return processed_items
 end
 
 
@@ -421,7 +421,9 @@ function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
 
         -- Apply attributes
         if is_selected and self.selected_attr then
-          s[#s+1] = function() return text.push_seq(self.selected_attr) end
+          s[#s + 1] = function()
+            return text.push_seq(self.selected_attr)
+          end
         end
         s[#s+1] = visible_tab_text
         if is_selected and self.selected_attr then
@@ -434,17 +436,17 @@ function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
 
     -- Add padding if visible
     if i < #self.items then
-        local padding_start = tab_end
-        local padding_end = padding_start + self.padding
-        if padding_end > visible_start and padding_start < visible_end then
-            local padding_visible_start_col = math.max(0, visible_start - padding_start)
-            local padding_visible_end_col = math.min(self.padding, visible_end - padding_start)
-            if padding_visible_end_col > padding_visible_start_col then
-                local padding_width = padding_visible_end_col - padding_visible_start_col
-                s[#s + 1] = string.rep(" ", padding_width)
-                rendered_width = rendered_width + padding_width
-            end
+      local padding_start = tab_end
+      local padding_end = padding_start + self.padding
+      if padding_end > visible_start and padding_start < visible_end then
+        local padding_visible_start_col = math.max(0, visible_start - padding_start)
+        local padding_visible_end_col = math.min(self.padding, visible_end - padding_start)
+        if padding_visible_end_col > padding_visible_start_col then
+          local padding_width = padding_visible_end_col - padding_visible_start_col
+          s[#s + 1] = string.rep(" ", padding_width)
+          rendered_width = rendered_width + padding_width
         end
+      end
     end
 
     -- Stop if we've filled the available width
@@ -465,7 +467,9 @@ function TabStrip:_build_tab_line(available_width)
 
   -- Apply global attr if specified
   if self.attr then
-    s[#s+1] = function() return text.push_seq(self.attr) end
+    s[#s + 1] = function()
+      return text.push_seq(self.attr)
+    end
   end
 
   -- Handle empty items
@@ -484,7 +488,8 @@ function TabStrip:_build_tab_line(available_width)
   self:_adjust_viewport_for_selected()
 
   -- Calculate effective width and overflow indicators
-  local has_left_overflow, has_right_overflow, effective_width = self:_calculate_total_content_width_and_overflow(available_width)
+  local has_left_overflow, has_right_overflow, effective_width =
+    self:_calculate_total_content_width_and_overflow(available_width)
   local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
   -- Build output with overflow indicators

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -21,7 +21,13 @@ local MAX_HEIGHT = 1
 
 
 
-local tab_strip = utils.class(Panel)
+local cursor = terminal.cursor
+local cursor_pos = cursor.position
+local output = terminal.output
+
+
+
+local TabStrip = utils.class(Panel)
 
 
 
@@ -39,6 +45,91 @@ local default_config = {
 -- Get default ellipsis
 local ellipsis = default_config.ellipsis
 local ellipsis_width = default_config.ellipsis_width
+
+
+
+-- Local functions
+
+
+
+local function validate_items(items)
+    items = items or {}
+
+    local processed_items = {}
+
+    for i, item in ipairs(items) do
+        -- Validate item has required label field
+        if not item.label then
+            error("Tab item must have 'label' field, at index(" .. tostring(i) .. ")")
+        end
+
+        -- Create processed item with default id if missing
+        processed_items[i] = {
+            id = item.id or i,
+            label = item.label
+        }
+    end
+
+    return processed_items
+end
+
+
+
+local function _validate_option_types(opts)
+  if opts.prefix ~= nil and type(opts.prefix) ~= "string" then
+    error("prefix must be a string, got " .. type(opts.prefix))
+  end
+  if opts.postfix ~= nil and type(opts.postfix) ~= "string" then
+    error("postfix must be a string, got " .. type(opts.postfix))
+  end
+  if opts.padding ~= nil and type(opts.padding) ~= "number" then
+    error("padding must be a number, got " .. type(opts.padding))
+  end
+  if opts.select_cb ~= nil and type(opts.select_cb) ~= "function" then
+    error("select_cb must be a function, got " .. type(opts.select_cb))
+  end
+end
+
+
+
+local function filter(t, predicate)
+  local result = {}
+  for _, v in ipairs(t) do
+    if predicate(v) then
+      table.insert(result, v)
+    end
+  end
+  return result
+end
+
+
+
+function TabStrip:_handle_initial_selection(processed_items, selected)
+  local found = #filter(processed_items,
+    function(item)
+      return item.id == selected
+    end) > 0
+
+  for _, item in ipairs(processed_items) do
+    if item.id == selected then
+      found = true
+      break
+    end
+  end
+
+  if #processed_items == 0 then
+    self.selected = nil
+
+  elseif selected and found then
+    -- Validate selected id exists in items
+    self.selected = selected
+
+  else
+    -- Default to first tab (index 1)
+    self.selected = processed_items[1].id
+  end
+end
+
 
 
 --- Create a new TabStrip instance.
@@ -64,100 +155,7 @@ local ellipsis_width = default_config.ellipsis_width
 --     attr = { fg = "white", bg = "black" },
 --     selected_attr = { reverse = true }
 --   }
-
-
-
--- Local functions
-local function clear_opts(opts, keys)
-  for _, key in ipairs(keys) do
-    opts[key] = nil
-  end
-end
-
-
-
-local function shallow_copy_table(tbl)
-    local copy = {}
-    for k, v in pairs(tbl) do
-        copy[k] = v
-    end
-    return copy
-end
-
-
-
-local function process_items(items)
-  local processed_items = {}
-
-  if items then
-    for i, item in ipairs(items) do
-      -- Validate item has required label field
-      if not item.label then
-        error("Tab item must have 'label' field" .. tostring(i))
-      end
-
-      -- Create processed item with default id if missing
-      local processed_item = {
-        id = item.id or i,
-        label = item.label,
-      }
-
-      table.insert( processed_items, processed_item )
-    end
-  end
-
-  return processed_items
-end
-
-
-
-local function _validate_option_types(opts)
-  if opts.prefix ~= nil and type(opts.prefix) ~= "string" then
-    error("prefix must be a string, got " .. type(opts.prefix))
-  end
-  if opts.postfix ~= nil and type(opts.postfix) ~= "string" then
-    error("postfix must be a string, got " .. type(opts.postfix))
-  end
-  if opts.padding ~= nil and type(opts.padding) ~= "number" then
-    error("padding must be a number, got " .. type(opts.padding))
-  end
-  if opts.select_cb ~= nil and type(opts.select_cb) ~= "function" then
-    error("select_cb must be a function, got " .. type(opts.select_cb))
-  end
-end
-
-
-
-function tab_strip:_handle_initial_selection(processed_items, selected)
-  if #processed_items == 0 then
-    self.selected = nil
-
-  elseif selected then
-    -- Validate selected id exists in items
-    local found = false
-    for _, item in ipairs(processed_items) do
-      if item.id == selected then
-        found = true
-        break
-      end
-    end
-    if found then
-      self.selected = selected
-
-    else
-      -- Default to first tab if selected id not found
-      self.selected = processed_items[1].id
-    end
-
-  else
-    -- Default to first tab (index 1)
-    self.selected = processed_items[1].id
-  end
-end
-
-
-
-function tab_strip:init(opts)
+function TabStrip:init(opts)
   if not opts or type(opts) ~= "table" then
     error("missing argument: options table isn't given")
   end
@@ -185,8 +183,14 @@ function tab_strip:init(opts)
   end
 
   -- Remove TabStrip-specific options from opts to avoid conflicts with Panel
-  clear_opts(opts, { "items", "selected", "prefix", "postfix", "padding", "attr",
-                    "selected_attr", "select_cb" })
+  opts.items = nil
+  opts.selected = nil
+  opts.prefix = nil
+  opts.postfix = nil
+  opts.padding = nil
+  opts.attr = nil
+  opts.selected_attr = nil
+  opts.select_cb = nil
 
   -- Call parent constructor
   Panel.init(self, opts)
@@ -194,23 +198,19 @@ function tab_strip:init(opts)
   self._total_content_width = 0
 
   -- Process and validate items
-  local processed_items = process_items(items)
+  local processed_items = validate_items(items)
 
   -- Replace empty configurations with defaults
-  if not prefix then
-    prefix = default_config.prefix
-  end
-  if not postfix then
-    postfix = default_config.postfix
-  end
-  if not padding then
-    padding = default_config.padding
-  end
+  prefix = prefix or default_config.prefix
+  postfix = postfix or default_config.postfix
+  prefix = prefix or default_config.prefix
 
   -- Derive selected_attr from attr if not provided
   if not selected_attr and attr then
-    selected_attr = shallow_copy_table(attr)
-    
+    for k, v in pairs(attr) do
+      selected_attr[k] = v
+    end
+
     -- Invert reverse attribute
     if attr.reverse ~= nil then
       selected_attr.reverse = not attr.reverse
@@ -245,11 +245,7 @@ end
 
 -- Private method to draw the tab strip content.
 -- @return nothing
-function tab_strip:_draw_tabs()
-  local cursor = terminal.cursor
-  local cursor_pos = cursor.position
-  local output = terminal.output
-
+function TabStrip:_draw_tabs()
   output.write(
     cursor_pos.backup_seq(),
     cursor_pos.set_seq(self.inner_row, self.inner_col),
@@ -262,7 +258,7 @@ end
 
 -- Private method to invalidate cache.
 -- @return nothing
-function tab_strip:_invalidate_cache()
+function TabStrip:_invalidate_cache()
   self._cache_valid = false
 end
 
@@ -270,7 +266,7 @@ end
 
 -- Private method to reset viewport state.
 -- @return nothing
-function tab_strip:_reset_viewport_state()
+function TabStrip:_reset_viewport_state()
   self._tab_widths = {}
   self._tab_positions = {}
   self._total_content_width = 0
@@ -280,13 +276,13 @@ end
 
 -- Private method to build cache of tab widths and positions.
 -- @return nothing
-function tab_strip:_build_cache()
+function TabStrip:_build_cache()
   if self._cache_valid then
     return
   end
 
   self:_reset_viewport_state()
-  
+
   -- Calculate total content width and populate tab widths and positions
   self:_calculate_total_content_width()
 
@@ -297,7 +293,7 @@ end
 
 -- Private method to calculate total content width.
 -- @treturn number Total width of all tabs including padding.
-function tab_strip:_calculate_total_content_width()
+function TabStrip:_calculate_total_content_width()
   for i, item in ipairs(self.items) do
     -- Format tab: prefix + label + postfix
     local tab_text = self.prefix .. item.label .. self.postfix
@@ -323,7 +319,7 @@ end
 -- @treturn boolean has_left_overflow Whether there is overflow to the left.
 -- @treturn boolean has_right_overflow Whether there is overflow to the right.
 -- @treturn number effective_width The width available for rendering tabs after accounting for overflow indicators.
-function tab_strip:_calculate_total_content_width_and_overflow(available_width)
+function TabStrip:_calculate_total_content_width_and_overflow(available_width)
   local has_left_overflow = false
   local has_right_overflow = false
   local effective_width = available_width
@@ -353,7 +349,7 @@ end
 
 -- Private method to get index of selected tab.
 -- @treturn number|nil Index of selected tab, or nil if not found.
-function tab_strip:_get_selected_index()
+function TabStrip:_get_selected_index()
   for i, item in ipairs(self.items) do
     if item.id == self.selected then
       return i
@@ -366,7 +362,7 @@ end
 
 -- Private method to adjust viewport to show selected tab.
 -- @return nothing
-function tab_strip:_adjust_viewport_for_selected()
+function TabStrip:_adjust_viewport_for_selected()
   if #self.items == 0 or not self.selected then
     return
   end
@@ -428,7 +424,7 @@ end
 -- @tparam boolean has_left_overflow Whether there is overflow to the left (used to determine
 -- if we need to start with an ellipsis).
 -- @return number The total width of the rendered content (excluding overflow indicators).
-function tab_strip:_render_visible_content(s, effective_width, has_left_overflow)
+function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
   local visible_start = self._viewport_offset
   local visible_end = visible_start + effective_width
   local rendered_width = has_left_overflow and ellipsis_width or 0
@@ -492,7 +488,7 @@ end
 -- Private method to build the tab line sequence.
 -- @tparam number available_width Available width for the tab strip.
 -- @treturn Sequence The complete tab line sequence.
-function tab_strip:_build_tab_line(available_width)
+function TabStrip:_build_tab_line(available_width)
   local s = Sequence()
 
   -- Apply global attr if specified
@@ -557,7 +553,7 @@ end
 --   else
 --     print("Selected tab:", selected_id)
 --   end
-function tab_strip:get_selected()
+function TabStrip:get_selected()
   if #self.items == 0 then
     return nil, "no tabs available"
   end
@@ -575,7 +571,7 @@ end
 --   if not success then
 --     print("Error:", err)
 --   end
-function tab_strip:select(tab_id)
+function TabStrip:select(tab_id)
   if #self.items == 0 then
     return nil, "no tabs available"
   end
@@ -605,7 +601,7 @@ end
 --   if err then
 --     print("Error:", err)
 --   end
-function tab_strip:select_next()
+function TabStrip:select_next()
   if #self.items == 0 then
     return self:get_selected()
   end
@@ -643,7 +639,7 @@ end
 --   if err then
 --     print("Error:", err)
 --   end
-function tab_strip:select_prev()
+function TabStrip:select_prev()
   if #self.items == 0 then
     return self:get_selected()
   end
@@ -677,7 +673,7 @@ end
 -- @treturn table A copy of the items array.
 -- @usage
 --   local items = tab_strip:get_items()
-function tab_strip:get_items()
+function TabStrip:get_items()
   local copy = {}
   for i, item in ipairs(self.items) do
     copy[i] = {
@@ -698,9 +694,9 @@ end
 --     { id = "tab1", label = "Tab 1" },
 --     { id = "tab2", label = "Tab 2" }
 --   })
-function tab_strip:set_items(items)
+function TabStrip:set_items(items)
   -- Process and validate items
-  local processed_items = process_items(items)
+  local processed_items = validate_items(items)
 
   self.items = processed_items
   self:_invalidate_cache()
@@ -733,7 +729,7 @@ end
 -- @usage
 --   tab_strip:add_item({ id = "tab3", label = "Tab 3" })
 --   tab_strip:add_item({ id = "tab2.5", label = "Tab 2.5" }, "tab3")
-function tab_strip:add_item(item, before_id)
+function TabStrip:add_item(item, before_id)
   -- Validate item has required label field
   if not item.label then
     error("Tab item must have 'label' field")
@@ -769,7 +765,7 @@ end
 -- @treturn string|nil Error message if id not found.
 -- @usage
 --   local success, err = tab_strip:remove_item("tab2")
-function tab_strip:remove_item(id)
+function TabStrip:remove_item(id)
   -- Find the item to remove
   local remove_index = nil
   local was_selected = false
@@ -799,7 +795,7 @@ function tab_strip:remove_item(id)
       if self.select_cb then
         self.select_cb(self, nil)
       end
-      
+
     elseif remove_index == 1 then
       -- First tab removed, move to new first tab
       self.selected = self.items[1].id
@@ -821,4 +817,4 @@ end
 
 
 
-return tab_strip
+return TabStrip

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -16,34 +16,29 @@ local text = require("terminal.text")
 local Sequence = require("terminal.sequence")
 local width = require("terminal.text.width")
 local utf8sub_col = utils.utf8sub_col
-
-local function normalize_items(items)
-  items = items or {}
-  local out = {}
-
-  for i, item in ipairs(items) do
-    out[i] = {
-      id = item.id or i,
-      label = assert(item.label, "Tab item must have 'label' field"),
-    }
-  end
-
-  return out
-end
+local MIN_HEIGHT = 1
+local MAX_HEIGHT = 1
 
 
-local function resolve_initial_selection(items, selected)
-  for _, item in ipairs(items) do
-    if item.id == selected then
-      return selected
-    end
-  end
 
-  return (items[1] or {}).id
-end
+local tab_strip = utils.class(Panel)
 
 
-local TabStrip = utils.class(Panel)
+
+local default_config = {
+    prefix = "[",
+    postfix = "]",
+    padding = 1,
+    clear_content = false,
+    ellipsis = "…",
+    ellipsis_width = width.utf8swidth("…"),
+}
+
+
+
+-- Get default ellipsis
+local ellipsis = default_config.ellipsis
+local ellipsis_width = default_config.ellipsis_width
 
 
 --- Create a new TabStrip instance.
@@ -69,12 +64,103 @@ local TabStrip = utils.class(Panel)
 --     attr = { fg = "white", bg = "black" },
 --     selected_attr = { reverse = true }
 --   }
-function TabStrip:init(opts)
-  opts = opts or {}
 
-  -- Set fixed height of 1 line
-  opts.min_height = 1
-  opts.max_height = 1
+
+
+-- Local functions
+local function clear_opts(opts, keys)
+  for _, key in ipairs(keys) do
+    opts[key] = nil
+  end
+end
+
+
+
+local function shallow_copy_table(tbl)
+    local copy = {}
+    for k, v in pairs(tbl) do
+        copy[k] = v
+    end
+    return copy
+end
+
+
+
+local function process_items(items)
+  local processed_items = {}
+
+  if items then
+    for i, item in ipairs(items) do
+      -- Validate item has required label field
+      if not item.label then
+        error("Tab item must have 'label' field" .. tostring(i))
+      end
+
+      -- Create processed item with default id if missing
+      local processed_item = {
+        id = item.id or i,
+        label = item.label,
+      }
+
+      table.insert( processed_items, processed_item )
+    end
+  end
+
+  return processed_items
+end
+
+
+
+local function _validate_option_types(opts)
+  if opts.prefix ~= nil and type(opts.prefix) ~= "string" then
+    error("prefix must be a string, got " .. type(opts.prefix))
+  end
+  if opts.postfix ~= nil and type(opts.postfix) ~= "string" then
+    error("postfix must be a string, got " .. type(opts.postfix))
+  end
+  if opts.padding ~= nil and type(opts.padding) ~= "number" then
+    error("padding must be a number, got " .. type(opts.padding))
+  end
+  if opts.select_cb ~= nil and type(opts.select_cb) ~= "function" then
+    error("select_cb must be a function, got " .. type(opts.select_cb))
+  end
+end
+
+
+
+function tab_strip:_handle_initial_selection(processed_items, selected)
+  if #processed_items == 0 then
+    self.selected = nil
+
+  elseif selected then
+    -- Validate selected id exists in items
+    local found = false
+    for _, item in ipairs(processed_items) do
+      if item.id == selected then
+        found = true
+        break
+      end
+    end
+    if found then
+      self.selected = selected
+
+    else
+      -- Default to first tab if selected id not found
+      self.selected = processed_items[1].id
+    end
+
+  else
+    -- Default to first tab (index 1)
+    self.selected = processed_items[1].id
+  end
+end
+
+
+
+function tab_strip:init(opts)
+  if not opts or type(opts) ~= "table" then
+    error("missing argument: options table isn't given")
+  end
 
   -- TabStrip-specific properties (extract before calling parent)
   local items = opts.items
@@ -86,52 +172,45 @@ function TabStrip:init(opts)
   local selected_attr = opts.selected_attr
   local select_cb = opts.select_cb
 
-  -- Remove TabStrip-specific options from opts to avoid conflicts with Panel
-  opts.items = nil
-  opts.selected = nil
-  opts.prefix = nil
-  opts.postfix = nil
-  opts.padding = nil
-  opts.attr = nil
-  opts.selected_attr = nil
-  opts.select_cb = nil
+  -- Validate option types
+  _validate_option_types(opts)
+
+  -- Set fixed height of 1 line
+  opts.min_height = MIN_HEIGHT
+  opts.max_height = MAX_HEIGHT
 
   -- Provide content callback for parent constructor
   opts.content = function(self)
     self:_draw_tabs()
   end
 
+  -- Remove TabStrip-specific options from opts to avoid conflicts with Panel
+  clear_opts(opts, { "items", "selected", "prefix", "postfix", "padding", "attr",
+                    "selected_attr", "select_cb" })
+
   -- Call parent constructor
   Panel.init(self, opts)
-  self.clear_content = false
+  self.clear_content = default_config.clear_content
+  self._total_content_width = 0
 
-  local normalized_items = normalize_items(items)
+  -- Process and validate items
+  local processed_items = process_items(items)
 
-  -- Validate option types
-  if prefix ~= nil and type(prefix) ~= "string" then
-    error("prefix must be a string, got " .. type(prefix))
+  -- Replace empty configurations with defaults
+  if not prefix then
+    prefix = default_config.prefix
   end
-  if postfix ~= nil and type(postfix) ~= "string" then
-    error("postfix must be a string, got " .. type(postfix))
+  if not postfix then
+    postfix = default_config.postfix
   end
-  if padding ~= nil and type(padding) ~= "number" then
-    error("padding must be a number, got " .. type(padding))
+  if not padding then
+    padding = default_config.padding
   end
-  if select_cb ~= nil and type(select_cb) ~= "function" then
-    error("select_cb must be a function, got " .. type(select_cb))
-  end
-
-  -- Apply defaults for configuration parameters
-  prefix = prefix or "["
-  postfix = postfix or "]"
-  padding = padding or 1
 
   -- Derive selected_attr from attr if not provided
   if not selected_attr and attr then
-    selected_attr = {}
-    for k, v in pairs(attr) do
-      selected_attr[k] = v
-    end
+    selected_attr = shallow_copy_table(attr)
+    
     -- Invert reverse attribute
     if attr.reverse ~= nil then
       selected_attr.reverse = not attr.reverse
@@ -150,14 +229,11 @@ function TabStrip:init(opts)
   self.select_cb = select_cb
 
   -- Viewport management state
+  self:_reset_viewport_state()
   self._viewport_offset = 0
-  self._cache_valid = false
-  self._tab_widths = {}
-  self._tab_positions = {}
-  self._total_content_width = 0
 
   -- Handle initial selection
-  self.selected = resolve_initial_selection(normalized_items, selected)
+  self:_handle_initial_selection(processed_items, selected)
 
   -- Call select_cb during initialization if provided
   if self.select_cb then
@@ -166,43 +242,62 @@ function TabStrip:init(opts)
 end
 
 
+
 -- Private method to draw the tab strip content.
 -- @return nothing
-function TabStrip:_draw_tabs()
-  terminal.output.write(
-    terminal.cursor.position.backup_seq(),
-    terminal.cursor.position.set_seq(self.inner_row, self.inner_col),
+function tab_strip:_draw_tabs()
+  local cursor = terminal.cursor
+  local cursor_pos = cursor.position
+  local output = terminal.output
+
+  output.write(
+    cursor_pos.backup_seq(),
+    cursor_pos.set_seq(self.inner_row, self.inner_col),
     self:_build_tab_line(self.inner_width),
-    terminal.cursor.position.restore_seq()
+    cursor_pos.restore_seq()
   )
 end
 
 
+
 -- Private method to invalidate cache.
 -- @return nothing
-function TabStrip:_invalidate_cache()
+function tab_strip:_invalidate_cache()
   self._cache_valid = false
 end
 
--- Private method to find index of item with given id, or nil.
-function TabStrip:_index_by_id(id)
-  for i, item in ipairs(self.items) do
-    if item.id == id then
-      return i
-    end
-  end
-  return nil
+
+
+-- Private method to reset viewport state.
+-- @return nothing
+function tab_strip:_reset_viewport_state()
+  self._tab_widths = {}
+  self._tab_positions = {}
+  self._total_content_width = 0
 end
 
-local function build_cache(self)
+
+
+-- Private method to build cache of tab widths and positions.
+-- @return nothing
+function tab_strip:_build_cache()
   if self._cache_valid then
     return
   end
 
-  self._tab_widths = {}
-  self._tab_positions = {}
-  self._total_content_width = 0
+  self:_reset_viewport_state()
+  
+  -- Calculate total content width and populate tab widths and positions
+  self:_calculate_total_content_width()
 
+  self._cache_valid = true
+end
+
+
+
+-- Private method to calculate total content width.
+-- @treturn number Total width of all tabs including padding.
+function tab_strip:_calculate_total_content_width()
   for i, item in ipairs(self.items) do
     -- Format tab: prefix + label + postfix
     local tab_text = self.prefix .. item.label .. self.postfix
@@ -219,89 +314,16 @@ local function build_cache(self)
       self._total_content_width = self._total_content_width + self.padding
     end
   end
-
-  self._cache_valid = true
 end
 
-local function adjust_viewport_for_selected(self, ellipsis_width)
-  if #self.items == 0 or not self.selected then
-    return
-  end
 
-  build_cache(self)
 
-  local selected_index = self:_index_by_id(self.selected)
-  if not selected_index then
-    return
-  end
-
-  -- Calculate effective width (accounting for overflow indicators)
-  local effective_width = self.inner_width
-
-  if self._total_content_width > self.inner_width then
-    -- Need overflow indicators
-    effective_width = self.inner_width - (ellipsis_width * 2)
-  end
-
-  -- Get selected tab position and width
-  local tab_start = self._tab_positions[selected_index]
-  local tab_width = self._tab_widths[selected_index]
-  local tab_end = tab_start + tab_width
-
-  -- Adjust viewport to show selected tab
-  if tab_start < self._viewport_offset then
-    -- Tab is to the left of viewport, move viewport to show it
-    self._viewport_offset = tab_start
-  elseif tab_end > self._viewport_offset + effective_width then
-    -- Tab is to the right of viewport, move viewport to show it
-    if tab_width > effective_width then
-      -- Tab is wider than effective width, left-justify it
-      self._viewport_offset = tab_start
-    else
-      -- Show tab at the right edge
-      self._viewport_offset = tab_end - effective_width
-    end
-  end
-
-  -- Clamp viewport offset
-  if self._viewport_offset < 0 then
-    self._viewport_offset = 0
-  end
-  local max_offset = math.max(0, self._total_content_width - effective_width)
-  if self._viewport_offset > max_offset then
-    self._viewport_offset = max_offset
-  end
-end
-
--- Private method to build the tab line sequence.
+-- Private method to calculate effective width and overflow indicators.
 -- @tparam number available_width Available width for the tab strip.
--- @treturn Sequence The complete tab line sequence.
-function TabStrip:_build_tab_line(available_width)
-  local s = Sequence()
-  local ellipsis = "…"
-  local ellipsis_width = width.utf8cwidth(ellipsis)
-
-  -- Apply global attr if specified
-  if self.attr then
-    s[#s+1] = function() return text.push_seq(self.attr) end
-  end
-
-  -- Handle empty items
-  if #self.items == 0 then
-    s[#s+1] = string.rep(" ", available_width)
-    if self.attr then
-      s[#s+1] = text.pop_seq
-    end
-    return s
-  end
-
-  -- Build cache
-  build_cache(self)
-
-  -- Adjust viewport to show selected tab
-  adjust_viewport_for_selected(self, ellipsis_width)
-
-  -- Calculate effective width and overflow indicators
+-- @treturn boolean has_left_overflow Whether there is overflow to the left.
+-- @treturn boolean has_right_overflow Whether there is overflow to the right.
+-- @treturn number effective_width The width available for rendering tabs after accounting for overflow indicators.
+function tab_strip:_calculate_total_content_width_and_overflow(available_width)
   local has_left_overflow = false
   local has_right_overflow = false
   local effective_width = available_width
@@ -324,12 +346,89 @@ function TabStrip:_build_tab_line(available_width)
     has_right_overflow = (self._viewport_offset + effective_width < self._total_content_width)
   end
 
-  -- Build output with overflow indicators
-  if has_left_overflow then
-    s[#s+1] = ellipsis
+  return has_left_overflow, has_right_overflow, effective_width
+end
+
+
+
+-- Private method to get index of selected tab.
+-- @treturn number|nil Index of selected tab, or nil if not found.
+function tab_strip:_get_selected_index()
+  for i, item in ipairs(self.items) do
+    if item.id == self.selected then
+      return i
+    end
+  end
+  return nil
+end
+
+
+
+-- Private method to adjust viewport to show selected tab.
+-- @return nothing
+function tab_strip:_adjust_viewport_for_selected()
+  if #self.items == 0 or not self.selected then
+    return
   end
 
-  -- Render visible content with attributes
+  self:_build_cache()
+
+  -- Find selected tab index
+  local selected_index = self:_get_selected_index()
+
+  if not selected_index then
+    return
+  end
+
+  -- Calculate effective width (accounting for overflow indicators)
+  local effective_width = self.inner_width
+
+  if self._total_content_width > self.inner_width then
+    -- Need overflow indicators
+    effective_width = self.inner_width - (ellipsis_width * 2)
+  end
+
+  -- Get selected tab position and width
+  local tab_start = self._tab_positions[selected_index]
+  local tab_width = self._tab_widths[selected_index]
+  local tab_end = tab_start + tab_width
+
+  -- Adjust viewport to show selected tab
+  if tab_start < self._viewport_offset then
+    -- Tab is to the left of viewport, move viewport to show it
+    self._viewport_offset = tab_start
+
+  elseif tab_end > self._viewport_offset + effective_width then
+    -- Tab is to the right of viewport, move viewport to show it
+    if tab_width > effective_width then
+      -- Tab is wider than effective width, left-justify it
+      self._viewport_offset = tab_start
+
+    else
+      -- Show tab at the right edge
+      self._viewport_offset = tab_end - effective_width
+    end
+  end
+
+  -- Clamp viewport offset
+  if self._viewport_offset < 0 then
+    self._viewport_offset = 0
+  end
+  local max_offset = math.max(0, self._total_content_width - effective_width)
+  if self._viewport_offset > max_offset then
+    self._viewport_offset = max_offset
+  end
+end
+
+
+
+-- Private method to render the tab line sequence based on current viewport.
+-- @tparam Sequence s The sequence to append to.
+-- @tparam number effective_width The width available for rendering tabs after accounting for overflow indicators.
+-- @tparam boolean has_left_overflow Whether there is overflow to the left (used to determine
+-- if we need to start with an ellipsis).
+-- @return number The total width of the rendered content (excluding overflow indicators).
+function tab_strip:_render_visible_content(s, effective_width, has_left_overflow)
   local visible_start = self._viewport_offset
   local visible_end = visible_start + effective_width
   local rendered_width = has_left_overflow and ellipsis_width or 0
@@ -367,17 +466,17 @@ function TabStrip:_build_tab_line(available_width)
 
     -- Add padding if visible
     if i < #self.items then
-      local padding_start = tab_end
-      local padding_end = padding_start + self.padding
-      if padding_end > visible_start and padding_start < visible_end then
-        local padding_visible_start_col = math.max(0, visible_start - padding_start)
-        local padding_visible_end_col = math.min(self.padding, visible_end - padding_start)
-        if padding_visible_end_col > padding_visible_start_col then
-          local padding_width = padding_visible_end_col - padding_visible_start_col
-          s[#s+1] = string.rep(" ", padding_width)
-          rendered_width = rendered_width + padding_width
+        local padding_start = tab_end
+        local padding_end = padding_start + self.padding
+        if padding_end > visible_start and padding_start < visible_end then
+            local padding_visible_start_col = math.max(0, visible_start - padding_start)
+            local padding_visible_end_col = math.min(self.padding, visible_end - padding_start)
+            if padding_visible_end_col > padding_visible_start_col then
+                local padding_width = padding_visible_end_col - padding_visible_start_col
+                s[#s + 1] = string.rep(" ", padding_width)
+                rendered_width = rendered_width + padding_width
+            end
         end
-      end
     end
 
     -- Stop if we've filled the available width
@@ -385,6 +484,47 @@ function TabStrip:_build_tab_line(available_width)
       break
     end
   end
+  return rendered_width
+end
+
+
+
+-- Private method to build the tab line sequence.
+-- @tparam number available_width Available width for the tab strip.
+-- @treturn Sequence The complete tab line sequence.
+function tab_strip:_build_tab_line(available_width)
+  local s = Sequence()
+
+  -- Apply global attr if specified
+  if self.attr then
+    s[#s+1] = function() return text.push_seq(self.attr) end
+  end
+
+  -- Handle empty items
+  if #self.items == 0 then
+    s[#s+1] = string.rep(" ", available_width)
+    if self.attr then
+      s[#s+1] = text.pop_seq
+    end
+    return s
+  end
+
+  -- Build cache
+  self:_build_cache()
+
+  -- Adjust viewport to show selected tab
+  self:_adjust_viewport_for_selected()
+
+  -- Calculate effective width and overflow indicators
+  local has_left_overflow, has_right_overflow, effective_width = self:_calculate_total_content_width_and_overflow(available_width)
+
+  -- Build output with overflow indicators
+  if has_left_overflow then
+    s[#s+1] = ellipsis
+  end
+
+  -- Render visible content with attributes
+  local rendered_width = self:_render_visible_content(s, effective_width, has_left_overflow)
 
   if has_right_overflow then
     s[#s+1] = ellipsis
@@ -406,6 +546,7 @@ function TabStrip:_build_tab_line(available_width)
 end
 
 
+
 --- Get the currently selected tab id.
 -- @treturn any|nil The selected tab id, or nil if no tabs exist.
 -- @treturn string|nil Error message if no tabs exist.
@@ -416,12 +557,13 @@ end
 --   else
 --     print("Selected tab:", selected_id)
 --   end
-function TabStrip:get_selected()
+function tab_strip:get_selected()
   if #self.items == 0 then
     return nil, "no tabs available"
   end
   return self.selected
 end
+
 
 
 --- Select a tab by id.
@@ -433,7 +575,7 @@ end
 --   if not success then
 --     print("Error:", err)
 --   end
-function TabStrip:select(tab_id)
+function tab_strip:select(tab_id)
   if #self.items == 0 then
     return nil, "no tabs available"
   end
@@ -454,6 +596,7 @@ function TabStrip:select(tab_id)
 end
 
 
+
 --- Select the next tab.
 -- @treturn any|nil The selected tab id, or nil if no tabs exist.
 -- @treturn string|nil Error message if no tabs exist.
@@ -462,12 +605,15 @@ end
 --   if err then
 --     print("Error:", err)
 --   end
-function TabStrip:select_next()
+function tab_strip:select_next()
   if #self.items == 0 then
     return self:get_selected()
   end
 
-  local current_index = self:_index_by_id(self.selected)
+  -- Find current index
+  local current_index = self:_get_selected_index()
+
+  -- If current_index is nil, something went wrong, default to first
   if not current_index then
     current_index = 1
   end
@@ -488,6 +634,7 @@ function TabStrip:select_next()
 end
 
 
+
 --- Select the previous tab.
 -- @treturn any|nil The selected tab id, or nil if no tabs exist.
 -- @treturn string|nil Error message if no tabs exist.
@@ -496,12 +643,15 @@ end
 --   if err then
 --     print("Error:", err)
 --   end
-function TabStrip:select_prev()
+function tab_strip:select_prev()
   if #self.items == 0 then
     return self:get_selected()
   end
 
-  local current_index = self:_index_by_id(self.selected)
+  -- Find current index
+  local current_index = self:_get_selected_index()
+
+  -- If current_index is nil, something went wrong, default to first
   if not current_index then
     current_index = 1
   end
@@ -522,20 +672,22 @@ function TabStrip:select_prev()
 end
 
 
+
 --- Get a copy of the items table.
 -- @treturn table A copy of the items array.
 -- @usage
 --   local items = tab_strip:get_items()
-function TabStrip:get_items()
+function tab_strip:get_items()
   local copy = {}
   for i, item in ipairs(self.items) do
     copy[i] = {
       id = item.id,
-      label = item.label
+      label = item.label,
     }
   end
   return copy
 end
+
 
 
 --- Set the items table.
@@ -546,16 +698,32 @@ end
 --     { id = "tab1", label = "Tab 1" },
 --     { id = "tab2", label = "Tab 2" }
 --   })
-function TabStrip:set_items(items)
-  local old_selected = self.selected
-  self.items = normalize_items(items)
+function tab_strip:set_items(items)
+  -- Process and validate items
+  local processed_items = process_items(items)
+
+  self.items = processed_items
   self:_invalidate_cache()
   self.selected = resolve_initial_selection(self.items, old_selected)
 
-  if self.selected ~= old_selected and self.select_cb then
-    self.select_cb(self, self.selected)
+  -- Adjust selection: validate it still exists, or default to first
+  if #processed_items == 0 then
+    self.selected = nil
+
+  else
+    local found = false
+    for _, item in ipairs(processed_items) do
+      if item.id == self.selected then
+        found = true
+        break
+      end
+    end
+    if not found then
+      self.selected = processed_items[1].id
+    end
   end
 end
+
 
 
 --- Add a new item to the items list.
@@ -565,14 +733,16 @@ end
 -- @usage
 --   tab_strip:add_item({ id = "tab3", label = "Tab 3" })
 --   tab_strip:add_item({ id = "tab2.5", label = "Tab 2.5" }, "tab3")
-function TabStrip:add_item(item, before_id)
+function tab_strip:add_item(item, before_id)
   -- Validate item has required label field
-  assert(item.label, "Tab item must have 'label' field")
+  if not item.label then
+    error("Tab item must have 'label' field")
+  end
 
   -- Process item with default id if missing
   local processed_item = {
     id = item.id or (#self.items + 1),
-    label = item.label
+    label = item.label,
   }
 
   if before_id then
@@ -592,14 +762,26 @@ function TabStrip:add_item(item, before_id)
 end
 
 
+
 --- Remove an item from the items list.
 -- @tparam any id The id of the item to remove.
 -- @treturn boolean|nil True on success, or nil if id not found.
 -- @treturn string|nil Error message if id not found.
 -- @usage
 --   local success, err = tab_strip:remove_item("tab2")
-function TabStrip:remove_item(id)
-  local remove_index = self:_index_by_id(id)
+function tab_strip:remove_item(id)
+  -- Find the item to remove
+  local remove_index = nil
+  local was_selected = false
+
+  for i, item in ipairs(self.items) do
+    if item.id == id then
+      remove_index = i
+      was_selected = (item.id == self.selected)
+      break
+    end
+  end
+
   if not remove_index then
     return nil, "tab id not found"
   end
@@ -617,12 +799,14 @@ function TabStrip:remove_item(id)
       if self.select_cb then
         self.select_cb(self, nil)
       end
+      
     elseif remove_index == 1 then
       -- First tab removed, move to new first tab
       self.selected = self.items[1].id
       if self.select_cb then
         self.select_cb(self, self.selected)
       end
+
     else
       -- Move selection to left tab
       self.selected = self.items[remove_index - 1].id
@@ -636,5 +820,5 @@ function TabStrip:remove_item(id)
 end
 
 
-return TabStrip
 
+return tab_strip

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -34,17 +34,10 @@ local TabStrip = utils.class(Panel)
 local default_config = {
     prefix = "[",
     postfix = "]",
-    padding = 1,
     clear_content = false,
     ellipsis = "…",
-    ellipsis_width = width.utf8swidth("…"),
+    padding = 1
 }
-
-
-
--- Get default ellipsis
-local ellipsis = default_config.ellipsis
-local ellipsis_width = default_config.ellipsis_width
 
 
 
@@ -203,10 +196,11 @@ function TabStrip:init(opts)
   -- Replace empty configurations with defaults
   prefix = prefix or default_config.prefix
   postfix = postfix or default_config.postfix
-  prefix = prefix or default_config.prefix
+  padding = padding or default_config.padding
 
   -- Derive selected_attr from attr if not provided
   if not selected_attr and attr then
+    selected_attr = {}
     for k, v in pairs(attr) do
       selected_attr[k] = v
     end
@@ -323,6 +317,7 @@ function TabStrip:_calculate_total_content_width_and_overflow(available_width)
   local has_left_overflow = false
   local has_right_overflow = false
   local effective_width = available_width
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
   if self._total_content_width > available_width then
     -- Need overflow indicators
@@ -378,6 +373,7 @@ function TabStrip:_adjust_viewport_for_selected()
 
   -- Calculate effective width (accounting for overflow indicators)
   local effective_width = self.inner_width
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
   if self._total_content_width > self.inner_width then
     -- Need overflow indicators
@@ -425,6 +421,7 @@ end
 -- if we need to start with an ellipsis).
 -- @return number The total width of the rendered content (excluding overflow indicators).
 function TabStrip:_render_visible_content(s, effective_width, has_left_overflow)
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
   local visible_start = self._viewport_offset
   local visible_end = visible_start + effective_width
   local rendered_width = has_left_overflow and ellipsis_width or 0
@@ -513,17 +510,18 @@ function TabStrip:_build_tab_line(available_width)
 
   -- Calculate effective width and overflow indicators
   local has_left_overflow, has_right_overflow, effective_width = self:_calculate_total_content_width_and_overflow(available_width)
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
 
   -- Build output with overflow indicators
   if has_left_overflow then
-    s[#s+1] = ellipsis
+    s[#s+1] = default_config.ellipsis
   end
 
   -- Render visible content with attributes
   local rendered_width = self:_render_visible_content(s, effective_width, has_left_overflow)
 
   if has_right_overflow then
-    s[#s+1] = ellipsis
+    s[#s+1] = default_config.ellipsis
     rendered_width = rendered_width + ellipsis_width
   end
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -50,7 +50,6 @@ local default_config = {
 -- If id is missing, use index as id
 local function validate_items(items)
   items = items or {}
-
   local processed_items = {}
 
   for i, item in ipairs(items) do
@@ -69,7 +68,7 @@ end
 
 
 
-local function _validate_option_types(opts)
+local function validate_option_types(opts)
   if opts.prefix ~= nil and type(opts.prefix) ~= "string" then
     error("prefix must be a string, got " .. type(opts.prefix))
   end
@@ -86,16 +85,20 @@ end
 
 
 
-function TabStrip:_handle_initial_selection(items, selected)
+-- Validate selection against items, returns valid selection
+-- If selected is not found in items, returns first item id, or nil if no items
+-- @tparam table items The array of tab items
+-- @tparam any selected The selected tab ID to validate
+-- @return any|nil The validated selected tab ID. If not found, 1st entry, or nil if there are no items.
+local function set_selection(items, selected)
   for _, item in ipairs(items) do
     if item.id == selected then
-      self.selected = selected
-      return
+      return selected
     end
   end
 
   -- not found, pick first item, or nil if no items
-  self.selected = (items[1] or {}).id
+  return (items[1] or {}).id
 end
 
 
@@ -139,7 +142,7 @@ function TabStrip:init(opts)
   local select_cb = opts.select_cb
 
   -- Validate option types
-  _validate_option_types(opts)
+  validate_option_types(opts)
 
   -- Set fixed height of 1 line
   opts.min_height = MIN_HEIGHT
@@ -202,7 +205,7 @@ function TabStrip:init(opts)
   self._viewport_offset = 0
 
   -- Handle initial selection
-  self:_handle_initial_selection(processed_items, selected)
+  self.selected = set_selection(processed_items, selected)
 
   -- Call select_cb during initialization if provided
   if self.select_cb then
@@ -306,6 +309,7 @@ function TabStrip:_calculate_total_content_width_and_overflow(available_width)
     effective_width = available_width - ellipsis_width
     -- Recalculate has_right_overflow with adjusted effective_width for consistency
     has_right_overflow = (self._viewport_offset + effective_width < self._total_content_width)
+
   elseif has_right_overflow and not has_left_overflow then
     effective_width = available_width - ellipsis_width
     -- Recalculate has_right_overflow with adjusted effective_width for consistency
@@ -317,22 +321,7 @@ end
 
 
 
--- Private method to get index of selected tab.
--- @treturn number|nil Index of selected tab, or nil if not found.
-function TabStrip:_get_selected_index()
-  for i, item in ipairs(self.items) do
-    if item.id == self.selected then
-      return i
-    end
-  end
-  return nil
-end
-
-
-
--- Private method to adjust viewport to show selected tab.
--- @return nothing
-function TabStrip:_adjust_viewport_for_selected()
+function TabStrip:adjust_viewport_for_selected()
   if #self.items == 0 or not self.selected then
     return
   end
@@ -385,6 +374,68 @@ function TabStrip:_adjust_viewport_for_selected()
   if self._viewport_offset > max_offset then
     self._viewport_offset = max_offset
   end
+end
+
+
+
+-- Private method to build the tab line sequence.
+-- @tparam number available_width Available width for the tab strip.
+-- @treturn Sequence The complete tab line sequence.
+function TabStrip:_build_tab_line(available_width)
+  local s = Sequence()
+
+  -- Apply global attr if specified
+  if self.attr then
+    s[#s + 1] = function()
+      return text.push_seq(self.attr)
+    end
+  end
+
+  -- Handle empty items
+  if #self.items == 0 then
+    s[#s+1] = string.rep(" ", available_width)
+    if self.attr then
+      s[#s+1] = text.pop_seq
+    end
+    return s
+  end
+
+  -- Build cache
+  self:_build_cache()
+
+  -- Adjust viewport to show selected tab
+  self:adjust_viewport_for_selected()
+
+  -- Calculate effective width and overflow indicators
+  local has_left_overflow, has_right_overflow, effective_width =
+    self:_calculate_total_content_width_and_overflow(available_width)
+  local ellipsis_width = width.utf8swidth(default_config.ellipsis)
+
+  -- Build output with overflow indicators
+  if has_left_overflow then
+    s[#s+1] = default_config.ellipsis
+  end
+
+  -- Render visible content with attributes
+  local rendered_width = self:_render_visible_content(s, effective_width, has_left_overflow)
+
+  if has_right_overflow then
+    s[#s+1] = default_config.ellipsis
+    rendered_width = rendered_width + ellipsis_width
+  end
+
+  -- Fill remaining width with spaces
+  local remaining = available_width - rendered_width
+  if remaining > 0 then
+    s[#s+1] = string.rep(" ", remaining)
+  end
+
+  -- Pop global attr if specified
+  if self.attr then
+    s[#s+1] = text.pop_seq
+  end
+
+  return s
 end
 
 
@@ -532,7 +583,7 @@ end
 --     print("Selected tab:", selected_id)
 --   end
 function TabStrip:get_selected()
-  if #self.items == 0 then
+  if not self.selected then
     return nil, "no tabs available"
   end
   return self.selected
@@ -550,20 +601,19 @@ end
 --     print("Error:", err)
 --   end
 function TabStrip:select(tab_id)
-  if #self.items == 0 then
-    return nil, "no tabs available"
+  local new_selection = set_selection(self.items, tab_id)
+
+  if new_selection ~= tab_id then
+    return nil, "tab id not found: '" .. tostring(tab_id) .. "'"
   end
 
-  if not self:_index_by_id(tab_id) then
-    return nil, "tab id not found"
+  if self.selected == tab_id then
+    return true  -- No change, this ID was already selected
   end
 
-  -- Only update and call callback if selection actually changed
-  if self.selected ~= tab_id then
-    self.selected = tab_id
-    if self.select_cb then
-      self.select_cb(self, tab_id)
-    end
+  self.selected = tab_id
+  if self.select_cb then  -- TODO: callabck alwasy set, a NOOp if not provided, to forego on these checks
+    self:select_cb(tab_id)
   end
 
   return true

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -97,30 +97,16 @@ end
 
 
 
-function TabStrip:_handle_initial_selection(processed_items, selected)
-  local found = #filter(processed_items,
-    function(item)
-      return item.id == selected
-    end) > 0
-
-  for _, item in ipairs(processed_items) do
+function TabStrip:_handle_initial_selection(items, selected)
+  for _, item in ipairs(items) do
     if item.id == selected then
-      found = true
-      break
+      self.selected = selected
+      return
     end
   end
 
-  if #processed_items == 0 then
-    self.selected = nil
-
-  elseif selected and found then
-    -- Validate selected id exists in items
-    self.selected = selected
-
-  else
-    -- Default to first tab (index 1)
-    self.selected = processed_items[1].id
-  end
+  -- not found, pick first item, or nil if no items
+  self.selected = (items[1] or {}).id 
 end
 
 

--- a/src/terminal/ui/panel/tab_strip.lua
+++ b/src/terminal/ui/panel/tab_strip.lua
@@ -156,7 +156,7 @@ end
 --     selected_attr = { reverse = true }
 --   }
 function TabStrip:init(opts)
-  if not opts or type(opts) ~= "table" then
+  if type(opts) ~= "table" then
     error("missing argument: options table isn't given")
   end
 


### PR DESCRIPTION
Extract helper functions for item processing, option validation, viewport state management, and tab line rendering. Add _get_selected_index to eliminate repeated lookup loops. Combine defaults into default_config and move constants to module level.