### PR TITLE
feat(ui): add arc primitive to Canvas and CanvasViewport

### DIFF
--- a/examples/canvas.lua
+++ b/examples/canvas.lua
@@ -23,27 +23,20 @@ local anchor_idx = 1
 
 
 
--- Draw a dashed circle through the viewport by walking arc-length (~1 pixel per step).
+-- Draw a dashed circle as a sequence of arcs.
+-- dash and gap are lengths in virtual pixels; each maps to an angular extent via r.
 local function dashed_circle(vp, cx, cy, r, dash, gap)
-  local step = 1.0 / r
-  local drawing = true
-  local toggle = dash
-  local px, py
-
-  local angle = 0
-  while angle < 2 * math.pi + step do
-    local x = math.floor(cx + r * math.cos(angle) + 0.5)
-    local y = math.floor(cy + r * math.sin(angle) + 0.5)
-    if drawing and (x ~= px or y ~= py) then
-      vp:set(x, y)
-      px, py = x, y
-    end
-    toggle = toggle - 1
-    if toggle <= 0 then
-      drawing = not drawing
-      toggle = drawing and dash or gap
-    end
-    angle = angle + step
+  local dash_angle = dash / r
+  local cycle_angle = (dash + gap) / r
+  local two_pi = 2 * math.pi
+  local theta = 0
+  while theta < two_pi do
+    vp:arc({
+      x = cx, y = cy, rx = r, ry = r,
+      angle_start = theta,
+      angle_end = math.min(theta + dash_angle, two_pi),
+    })
+    theta = theta + cycle_angle
   end
 end
 

--- a/spec/70-canvas_spec.lua
+++ b/spec/70-canvas_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local lines = require("pl.stringx").splitlines
 
 -- Mirror of canvas's internal braille() encoder, for computing expected cell values.
 -- DOT_BIT (col, row) → bit: (0,0)=1, (0,1)=2, (0,2)=4, (0,3)=64,
@@ -870,6 +871,194 @@ describe("terminal.ui.canvas", function()
         -- circle centred near edge so part of the outline falls outside
         local c = Canvas({ width = 2, height = 2 })
         assert.has_no_error(function() c:circle({ x = 0, y = 0, r = 3 }) end)
+      end)
+
+    end)
+
+
+
+    describe("arc()", function()
+
+      -- Helper: render canvas to a table of braille-string lines.
+      local function render_lines(c)
+        return lines(c:render({ print = true }))
+      end
+
+      local pi = math.pi
+
+
+      it("draws a single pixel when rx and ry are both zero", function()
+        -- rx=ry=0: degenerate point at (cx, cy) regardless of angles.
+        -- cx=0,cy=0 on 1×1 canvas: pixel (0,0) → col=0,row=0,bit=1 → ⠁
+        local c = Canvas({ width = 1, height = 1 })
+        c:arc({ x = 0, y = 0, rx = 0, ry = 0, angle_start = 0, angle_end = 0 })
+        assert.are.same({ "⠁" }, render_lines(c))
+      end)
+
+
+      it("always plots the start-angle pixel", function()
+        -- angle_start = angle_end = 0: arc degenerates to a single point.
+        -- cx=4, cy=4, r=4 on 5×3 canvas (px_w=10, px_h=12).
+        -- At θ=0: x=floor(4+4+0.5)=8, y=4 → cell[2][5], dot_col=0,row=0, bit=1 → ⠁
+        local c = Canvas({ width = 5, height = 3 })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = 0 })
+        assert.are.same(
+          { "⠀⠀⠀⠀⠀",
+            "⠀⠀⠀⠀⠁",
+            "⠀⠀⠀⠀⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("always plots the end-angle pixel", function()
+        -- angle_start = angle_end = pi/2: arc degenerates to a single point at the bottom.
+        -- At θ=pi/2: x=4, y=floor(4+4+0.5)=8 → cell[3][3], dot_col=0,row=0, bit=1 → ⠁
+        local c = Canvas({ width = 5, height = 3 })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = pi/2, angle_end = pi/2 })
+        assert.are.same(
+          { "⠀⠀⠀⠀⠀",
+            "⠀⠀⠀⠀⠀",
+            "⠀⠀⠁⠀⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("a full revolution produces the expected closed outline", function()
+        -- cx=4, cy=4, r=4 on 5×3 canvas; one full revolution via parametric walk.
+        local c = Canvas({ width = 5, height = 3 })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = 2*pi })
+        assert.are.same(
+          { "⡰⠉⠉⠲⡀",
+            "⢧⠀⠀⣀⠇",
+            "⠀⠉⠉⠀⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("a quarter arc (pi/2) only sets pixels in the expected quadrant", function()
+        -- 0..pi/2 sweeps clockwise from the right to the bottom of the circle.
+        -- All pixels lie in the bottom-right quadrant of the canvas; the top row
+        -- and the left two columns stay entirely blank.
+        -- cx=4, cy=4, r=4 on 5×3 canvas.
+        local c = Canvas({ width = 5, height = 3 })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = pi/2 })
+        assert.are.same(
+          { "⠀⠀⠀⠀⠀",
+            "⠀⠀⠀⣀⠇",
+            "⠀⠀⠉⠀⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("a half arc (pi) only sets pixels on one side of the centre", function()
+        -- 0..pi sweeps the bottom half of the circle; the top row is entirely blank.
+        -- cx=4, cy=4, r=4 on 5×3 canvas.
+        local c = Canvas({ width = 5, height = 3 })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = pi })
+        assert.are.same(
+          { "⠀⠀⠀⠀⠀",
+            "⢧⠀⠀⣀⠇",
+            "⠀⠉⠉⠀⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("rx=0 draws a vertical segment for the given angle range", function()
+        -- rx=0 forces x=cx for every angle; only ry*sin(θ) varies.
+        -- cx=2, cy=6, ry=4 on 2×3 canvas (px_h=12); arc from -pi/2 to pi/2
+        -- spans y=6-4=2 to y=6+4=10 at x=2 (right column, cell_col=2).
+        -- row1[2]: y=2(bit4)+y=3(bit64)=68 → ⡄
+        -- row2[2]: y=4(bit1)+y=5(bit2)+y=6(bit4)+y=7(bit64)=71 → ⡇
+        -- row3[2]: y=8(bit1)+y=9(bit2)+y=10(bit4)=7 → ⠇
+        local c = Canvas({ width = 2, height = 3 })
+        c:arc({ x = 2, y = 6, rx = 0, ry = 4, angle_start = -pi/2, angle_end = pi/2 })
+        assert.are.same(
+          { "⠀⡄",
+            "⠀⡇",
+            "⠀⠇" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("ry=0 draws a horizontal segment for the given angle range", function()
+        -- ry=0 forces y=cy for every angle; only rx*cos(θ) varies.
+        -- cx=4, cy=2, rx=4 on 3×1 canvas (px_w=6); arc from -pi to 0
+        -- spans x=4-4=0 to x=4+4=8 at y=2, clipped to x=0..5.
+        -- All three cells: y=2 → cell_row=1, dot_row=2; left bit=4, right bit=32;
+        -- each cell has bits 4+32=36 → ⠤
+        local c = Canvas({ width = 3, height = 1 })
+        c:arc({ x = 4, y = 2, rx = 4, ry = 0, angle_start = -pi, angle_end = 0 })
+        assert.are.same({ "⠤⠤⠤" }, render_lines(c))
+      end)
+
+
+      it("erases pixels when the erase flag is set", function()
+        -- Use an inverted canvas (starts fully lit) so that erasing the arc cuts
+        -- visible holes in the solid background, making the effect directly observable.
+        -- Restoring with a plain arc fills the holes and returns the canvas to all-lit.
+        local c = Canvas({ width = 5, height = 3, invert = true })
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = pi/2, erase = true })
+        assert.are.same(
+          { "⣿⣿⣿⣿⣿",
+            "⣿⣿⣿⠿⣸",
+            "⣿⣿⣶⣿⣿" },
+          render_lines(c)
+        )
+        c:arc({ x = 4, y = 4, rx = 4, ry = 4, angle_start = 0, angle_end = pi/2 })
+        assert.are.same(
+          { "⣿⣿⣿⣿⣿",
+            "⣿⣿⣿⣿⣿",
+            "⣿⣿⣿⣿⣿" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("ignores out-of-bounds pixels when the arc extends beyond the canvas edge", function()
+        -- Circle centred at the top-left corner so most of it falls outside.
+        -- No error; the in-bounds pixels are still drawn.
+        local c = Canvas({ width = 2, height = 2 })
+        assert.has_no_error(function()
+          c:arc({ x = 0, y = 0, rx = 4, ry = 4, angle_start = 0, angle_end = 2*pi })
+        end)
+        assert.are.same(
+          { "⠀⣀",
+            "⠉⠀" },
+          render_lines(c)
+        )
+      end)
+
+
+      it("errors when angle_end is less than angle_start", function()
+        local c = Canvas({ width = 2, height = 2 })
+        assert.has_error(
+          function() c:arc({ x = 2, y = 4, rx = 2, ry = 2, angle_start = pi, angle_end = 0 }) end,
+          "angle_end must be >= angle_start"
+        )
+      end)
+
+
+      it("errors when rx or ry is negative", function()
+        -- negative radii produce a non-positive step denominator, causing an infinite loop
+        local c = Canvas({ width = 2, height = 2 })
+        assert.has_error(
+          function() c:arc({ x = 2, y = 2, rx = -1, ry =  1, angle_start = 0, angle_end = pi }) end,
+          "rx and ry must be >= 0"
+        )
+        assert.has_error(
+          function() c:arc({ x = 2, y = 2, rx =  1, ry = -1, angle_start = 0, angle_end = pi }) end,
+          "rx and ry must be >= 0"
+        )
+        assert.has_error(
+          function() c:arc({ x = 2, y = 2, rx = -1, ry = -1, angle_start = 0, angle_end = pi }) end,
+          "rx and ry must be >= 0"
+        )
       end)
 
     end)

--- a/spec/70-canvas_spec.lua
+++ b/spec/70-canvas_spec.lua
@@ -1,12 +1,19 @@
 local helpers = require "spec.helpers"
 local lines = require("pl.stringx").splitlines
 
+
+local function render_lines(c)
+  return lines(c:render({ print = true }))
+end
+
+
 -- Mirror of canvas's internal braille() encoder, for computing expected cell values.
 -- DOT_BIT (col, row) → bit: (0,0)=1, (0,1)=2, (0,2)=4, (0,3)=64,
 --                           (1,0)=8, (1,1)=16, (1,2)=32, (1,3)=128
 local function braille(i)
   return string.char(226, 160 + math.floor(i / 64), 128 + (i % 64))
 end
+
 
 local BLANK  = braille(0)    -- U+2800, all dots off
 local FILLED = braille(255)  -- U+28FF, all dots on
@@ -80,21 +87,21 @@ describe("terminal.ui.canvas", function()
 
     it("defaults to blank (all-dots-off) cells", function()
       local c = Canvas({ width = 3, height = 2 })
-      for r = 1, 2 do
-        for col = 1, 3 do
-          assert.are.equal(BLANK, c.cells[r][col])
-        end
-      end
+      assert.are.same(
+        { "⠀⠀⠀",
+          "⠀⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("uses filled (all-dots-on) cells when invert option is set", function()
       local c = Canvas({ width = 3, height = 2, invert = true })
-      for r = 1, 2 do
-        for col = 1, 3 do
-          assert.are.equal(FILLED, c.cells[r][col])
-        end
-      end
+      assert.are.same(
+        { "⣿⣿⣿",
+          "⣿⣿⣿" },
+        render_lines(c)
+      )
     end)
 
   end)
@@ -104,60 +111,59 @@ describe("terminal.ui.canvas", function()
   describe("set()", function()
 
     it("illuminates a pixel", function()
+      -- pixel (0,1): dot_col=0, dot_row=1, bit=2 → second dot of left column
       local c = Canvas({ width = 2, height = 1 })
-      -- pixel (0,1): col=0, row=1, bit=2 → braille(2)
       c:set(0, 1)
-      assert.are.equal(braille(2), c.cells[1][1])
+      assert.are.same({ "⠂⠀" }, render_lines(c))
     end)
 
 
     it("on an already-set pixel is idempotent", function()
       local c = Canvas({ width = 2, height = 1 })
       c:set(0, 0)
-      local after_first = c.cells[1][1]
+      local after_first = render_lines(c)
       c:set(0, 0)
-      assert.are.equal(after_first, c.cells[1][1])
+      assert.are.same(after_first, render_lines(c))
     end)
 
 
     it("handles the top-left corner pixel (0, 0)", function()
+      -- pixel (0,0): dot_col=0, dot_row=0, bit=1 → top-left dot
       local c = Canvas({ width = 2, height = 1 })
-      -- pixel (0,0): col=0, row=0, bit=1 → braille(1)
       c:set(0, 0)
-      assert.are.equal(braille(1), c.cells[1][1])
+      assert.are.same({ "⠁⠀" }, render_lines(c))
     end)
 
 
     it("handles the bottom-right corner pixel", function()
-      local c = Canvas({ width = 2, height = 1 })
       -- px_w=4, px_h=4; bottom-right pixel is (3,3)
-      -- cell_col=floor(3/2)+1=2, cell_row=floor(3/4)+1=1
-      -- col=3%2=1, row=3%4=3, bit=128 → braille(128)
+      -- dot_col=1, dot_row=3, bit=128 → bottom-right dot of second cell
+      local c = Canvas({ width = 2, height = 1 })
       c:set(3, 3)
-      assert.are.equal(braille(128), c.cells[1][2])
+      assert.are.same({ "⠀⢀" }, render_lines(c))
     end)
 
 
     it("affects only the correct braille cell", function()
+      -- pixel (0,0) lands in cell [1][1]; all other cells stay blank
       local c = Canvas({ width = 2, height = 2 })
-      -- pixel (0,0) maps to cells[1][1] only
       c:set(0, 0)
-      assert.are_not.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[1][2])
-      assert.are.equal(BLANK, c.cells[2][1])
-      assert.are.equal(BLANK, c.cells[2][2])
+      assert.are.same(
+        { "⠁⠀",
+          "⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("ignores pixels outside canvas bounds", function()
-      -- 2×1 canvas: valid x=[0,3], valid y=[0,3]
+      -- 2×1 canvas: valid x=[0,3], valid y=[0,3]; all out-of-bounds sets are no-ops
       local c = Canvas({ width = 2, height = 1 })
       assert.has_no_error(function() c:set(-1,  0) end)  -- x too small
       assert.has_no_error(function() c:set( 4,  0) end)  -- x too large
       assert.has_no_error(function() c:set( 0, -1) end)  -- y too small
       assert.has_no_error(function() c:set( 0,  4) end)  -- y too large
-      assert.are.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
   end)
@@ -169,42 +175,39 @@ describe("terminal.ui.canvas", function()
     it("extinguishes a pixel", function()
       local c = Canvas({ width = 2, height = 1 })
       c:set(0, 0)
-      assert.are_not.equal(BLANK, c.cells[1][1])
+      assert.are.same({ "⠁⠀" }, render_lines(c))
       c:unset(0, 0)
-      assert.are.equal(BLANK, c.cells[1][1])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
 
     it("on an already-unset pixel is idempotent", function()
       local c = Canvas({ width = 2, height = 1 })
       c:unset(0, 0)
-      assert.are.equal(BLANK, c.cells[1][1])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
 
     it("in the same cell as set() is independent per dot", function()
+      -- (0,0): dot_col=0, dot_row=0, bit=1; (1,0): dot_col=1, dot_row=0, bit=8 — same cell
       local c = Canvas({ width = 2, height = 1 })
-      -- (0,0): col=0, row=0, bit=1; (1,0): col=1, row=0, bit=8 — same cell (1,1)
       c:set(0, 0)
       c:set(1, 0)
-      assert.are.equal(braille(1 + 8), c.cells[1][1])
+      assert.are.same({ "⠉⠀" }, render_lines(c))
       c:unset(0, 0)
-      assert.are.equal(braille(8), c.cells[1][1])
+      assert.are.same({ "⠈⠀" }, render_lines(c))
     end)
 
 
     it("ignores pixels outside canvas bounds", function()
-      -- 2×1 canvas: valid x=[0,3], valid y=[0,3]; pre-fill to detect unwanted changes
+      -- 2×1 canvas: valid x=[0,3], valid y=[0,3]; out-of-bounds unsets are no-ops
       local c = Canvas({ width = 2, height = 1 })
       c:set(0, 0)
-      local before1 = c.cells[1][1]
-      local before2 = c.cells[1][2]
       assert.has_no_error(function() c:unset(-1,  0) end)
       assert.has_no_error(function() c:unset( 4,  0) end)
       assert.has_no_error(function() c:unset( 0, -1) end)
       assert.has_no_error(function() c:unset( 0,  4) end)
-      assert.are.equal(before1, c.cells[1][1])
-      assert.are.equal(before2, c.cells[1][2])
+      assert.are.same({ "⠁⠀" }, render_lines(c))
     end)
 
   end)
@@ -215,14 +218,14 @@ describe("terminal.ui.canvas", function()
 
     it("resets all cells to blank after pixels were set", function()
       local c = Canvas({ width = 3, height = 2 })
-      c:set(0, 0)   -- cells[1][1]
+      c:set(0, 0)   -- top-left
       c:set(3, 5)   -- cell_col=2, cell_row=2
       c:clear()
-      for r = 1, 2 do
-        for col = 1, 3 do
-          assert.are.equal(BLANK, c.cells[r][col])
-        end
-      end
+      assert.are.same(
+        { "⠀⠀⠀",
+          "⠀⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
@@ -230,11 +233,11 @@ describe("terminal.ui.canvas", function()
       local c = Canvas({ width = 3, height = 2, invert = true })
       c:unset(0, 0)  -- extinguish one dot from the initially filled cell
       c:clear()
-      for r = 1, 2 do
-        for col = 1, 3 do
-          assert.are.equal(FILLED, c.cells[r][col])
-        end
-      end
+      assert.are.same(
+        { "⣿⣿⣿",
+          "⣿⣿⣿" },
+        render_lines(c)
+      )
     end)
 
   end)
@@ -252,12 +255,12 @@ describe("terminal.ui.canvas", function()
 
 
     it("cloned canvas has identical cell state", function()
+      -- set(0,0)→bit1 in cell[1][1], set(3,3)→bit128 in cell[1][2]
       local c = Canvas({ width = 2, height = 1 })
       c:set(0, 0)
       c:set(3, 3)
       local d = c:clone()
-      assert.are.equal(c.cells[1][1], d.cells[1][1])
-      assert.are.equal(c.cells[1][2], d.cells[1][2])
+      assert.are.same(render_lines(c), render_lines(d))
     end)
 
 
@@ -266,8 +269,8 @@ describe("terminal.ui.canvas", function()
       c:set(0, 0)
       local d = c:clone()
       d:unset(0, 0)
-      assert.are_not.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, d.cells[1][1])
+      assert.are.same({ "⠁⠀" }, render_lines(c))
+      assert.are.same({ "⠀⠀" }, render_lines(d))
     end)
 
 
@@ -304,67 +307,81 @@ describe("terminal.ui.canvas", function()
     it("growing rows adds blank rows at the bottom", function()
       local c = Canvas({ width = 1, height = 1 })
       c:resize(3, 1)
-      assert.are.equal(BLANK, c.cells[2][1])
-      assert.are.equal(BLANK, c.cells[3][1])
+      assert.are.same(
+        { "⠀",
+          "⠀",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("growing cols adds blank cells to the right of every row", function()
       local c = Canvas({ width = 1, height = 2 })
       c:resize(2, 3)
-      for r = 1, 2 do
-        assert.are.equal(BLANK, c.cells[r][2])
-        assert.are.equal(BLANK, c.cells[r][3])
-      end
+      assert.are.same(
+        { "⠀⠀⠀",
+          "⠀⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("shrinking rows removes rows from the bottom", function()
       local c = Canvas({ width = 1, height = 3 })
       c:resize(1, 1)
-      assert.is_nil(c.cells[2])
-      assert.is_nil(c.cells[3])
+      assert.are.same({ "⠀" }, render_lines(c))
     end)
 
 
     it("shrinking cols removes cells from the right of every row", function()
       local c = Canvas({ width = 3, height = 2 })
       c:resize(2, 1)
-      for r = 1, 2 do
-        assert.is_nil(c.cells[r][2])
-        assert.is_nil(c.cells[r][3])
-      end
+      assert.are.same(
+        { "⠀",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("preserves existing content within the new bounds", function()
+      -- set(0,0)→bit1, set(1,1)→bit16; same cell[1][1], total bits 1+16=17 → "⠑"
       local c = Canvas({ width = 3, height = 3 })
-      c:set(0, 0)  -- cells[1][1]
-      c:set(1, 1)  -- cells[1][1] (same cell, different dot)
-      local original = c.cells[1][1]
+      c:set(0, 0)
+      c:set(1, 1)
       c:resize(2, 2)
-      assert.are.equal(original, c.cells[1][1])
+      assert.are.same(
+        { "⠑⠀",
+          "⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("new cells respect the invert option", function()
       local c = Canvas({ width = 1, height = 1, invert = true })
       c:resize(2, 2)
-      assert.are.equal(FILLED, c.cells[1][2])
-      assert.are.equal(FILLED, c.cells[2][1])
-      assert.are.equal(FILLED, c.cells[2][2])
+      assert.are.same(
+        { "⣿⣿",
+          "⣿⣿" },
+        render_lines(c)
+      )
     end)
 
 
     it("same dimensions is a no-op", function()
       local c = Canvas({ width = 2, height = 2 })
       c:set(0, 0)
-      local before = c.cells[1][1]
       c:resize(2, 2)
       local rows, cols = c:get_size()
       assert.are.equal(2, rows)
       assert.are.equal(2, cols)
-      assert.are.equal(before, c.cells[1][1])
+      assert.are.same(
+        { "⠁⠀",
+          "⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
@@ -388,42 +405,46 @@ describe("terminal.ui.canvas", function()
   describe("scroll()", function()
 
     it("shifts content down, blanking the vacated top rows", function()
+      -- set(0,0)→bit1 in cell[1][1]; after scroll(1,0) it moves to cell[2][1]
       local c = Canvas({ width = 1, height = 2 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:scroll(1, 0)
-      assert.are.equal(BLANK,    c.cells[1][1])  -- vacated
-      assert.are.equal(original, c.cells[2][1])  -- content moved down
+      assert.are.same(
+        { "⠀",
+          "⠁" },
+        render_lines(c)
+      )
     end)
 
 
     it("shifts content up, blanking the vacated bottom rows", function()
+      -- set(0,4)→y=4→cell_row=2, bit1 in cell[2][1]; after scroll(-1,0) moves to cell[1][1]
       local c = Canvas({ width = 1, height = 2 })
-      c:set(0, 4)  -- y=4 → cell_row=2; cells[2][1]
-      local original = c.cells[2][1]
+      c:set(0, 4)
       c:scroll(-1, 0)
-      assert.are.equal(original, c.cells[1][1])  -- content moved up
-      assert.are.equal(BLANK,    c.cells[2][1])  -- vacated
+      assert.are.same(
+        { "⠁",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("shifts content right, blanking the vacated left cols", function()
+      -- set(0,0)→bit1 in cell[1][1]; after scroll(0,1) moves to cell[1][2]
       local c = Canvas({ width = 2, height = 1 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:scroll(0, 1)
-      assert.are.equal(BLANK,    c.cells[1][1])  -- vacated
-      assert.are.equal(original, c.cells[1][2])  -- content moved right
+      assert.are.same({ "⠀⠁" }, render_lines(c))
     end)
 
 
     it("shifts content left, blanking the vacated right cols", function()
+      -- set(2,0)→x=2→cell_col=2, bit1 in cell[1][2]; after scroll(0,-1) moves to cell[1][1]
       local c = Canvas({ width = 2, height = 1 })
-      c:set(2, 0)  -- x=2 → cell_col=2; cells[1][2]
-      local original = c.cells[1][2]
+      c:set(2, 0)
       c:scroll(0, -1)
-      assert.are.equal(original, c.cells[1][1])  -- content moved left
-      assert.are.equal(BLANK,    c.cells[1][2])  -- vacated
+      assert.are.same({ "⠁⠀" }, render_lines(c))
     end)
 
 
@@ -432,8 +453,11 @@ describe("terminal.ui.canvas", function()
       c:set(0, 0)
       c:set(0, 4)
       c:scroll(2, 0)
-      assert.are.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[2][1])
+      assert.are.same(
+        { "⠀",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
@@ -442,29 +466,32 @@ describe("terminal.ui.canvas", function()
       c:set(0, 0)
       c:set(2, 0)
       c:scroll(0, 2)
-      assert.are.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
 
     it("applies row and col shifts together", function()
+      -- set(0,0)→bit1 in cell[1][1]; after scroll(1,1) moves to cell[2][2]
       local c = Canvas({ width = 2, height = 2 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:scroll(1, 1)
-      assert.are.equal(BLANK,    c.cells[1][1])
-      assert.are.equal(BLANK,    c.cells[1][2])
-      assert.are.equal(BLANK,    c.cells[2][1])
-      assert.are.equal(original, c.cells[2][2])  -- moved down+right
+      assert.are.same(
+        { "⠀⠀",
+          "⠀⠁" },
+        render_lines(c)
+      )
     end)
 
 
     it("scroll(0, 0) is a no-op", function()
       local c = Canvas({ width = 2, height = 2 })
       c:set(0, 0)
-      local before = c.cells[1][1]
       c:scroll(0, 0)
-      assert.are.equal(before, c.cells[1][1])
+      assert.are.same(
+        { "⠁⠀",
+          "⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
@@ -483,78 +510,91 @@ describe("terminal.ui.canvas", function()
   describe("roll()", function()
 
     it("rolls content down, wrapping the bottom row to the top", function()
+      -- set(0,4)→y=4→cell_row=2, bit1 in cell[2][1]; after roll(1,0) wraps to cell[1][1]
       local c = Canvas({ width = 1, height = 2 })
-      c:set(0, 4)  -- y=4 → cell_row=2; cells[2][1]
-      local original = c.cells[2][1]
+      c:set(0, 4)
       c:roll(1, 0)
-      assert.are.equal(original, c.cells[1][1])  -- wrapped to top
-      assert.are.equal(BLANK,    c.cells[2][1])  -- moved up (was blank)
+      assert.are.same(
+        { "⠁",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("rolls content up, wrapping the top row to the bottom", function()
+      -- set(0,0)→bit1 in cell[1][1]; after roll(-1,0) wraps to cell[2][1]
       local c = Canvas({ width = 1, height = 2 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:roll(-1, 0)
-      assert.are.equal(BLANK,    c.cells[1][1])  -- moved down (was blank)
-      assert.are.equal(original, c.cells[2][1])  -- wrapped to bottom
+      assert.are.same(
+        { "⠀",
+          "⠁" },
+        render_lines(c)
+      )
     end)
 
 
     it("rolls content right, wrapping the last col to the left", function()
+      -- set(2,0)→x=2→cell_col=2, bit1 in cell[1][2]; after roll(0,1) wraps to cell[1][1]
       local c = Canvas({ width = 2, height = 1 })
-      c:set(2, 0)  -- x=2 → cell_col=2; cells[1][2]
-      local original = c.cells[1][2]
+      c:set(2, 0)
       c:roll(0, 1)
-      assert.are.equal(original, c.cells[1][1])  -- wrapped to left
-      assert.are.equal(BLANK,    c.cells[1][2])  -- moved right (was blank)
+      assert.are.same({ "⠁⠀" }, render_lines(c))
     end)
 
 
     it("rolls content left, wrapping the first col to the right", function()
+      -- set(0,0)→bit1 in cell[1][1]; after roll(0,-1) wraps to cell[1][2]
       local c = Canvas({ width = 2, height = 1 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:roll(0, -1)
-      assert.are.equal(BLANK,    c.cells[1][1])  -- moved left (was blank)
-      assert.are.equal(original, c.cells[1][2])  -- wrapped to right
+      assert.are.same({ "⠀⠁" }, render_lines(c))
     end)
 
 
     it("rolling by the canvas height is a no-op", function()
       local c = Canvas({ width = 1, height = 2 })
       c:set(0, 0)
-      local before = c.cells[1][1]
       c:roll(2, 0)
-      assert.are.equal(before, c.cells[1][1])
+      assert.are.same(
+        { "⠁",
+          "⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("rolling by the canvas width is a no-op", function()
       local c = Canvas({ width = 2, height = 1 })
       c:set(0, 0)
-      local before = c.cells[1][1]
       c:roll(0, 2)
-      assert.are.equal(before, c.cells[1][1])
+      assert.are.same({ "⠁⠀" }, render_lines(c))
     end)
 
 
     it("roll(0, 0) is a no-op", function()
       local c = Canvas({ width = 2, height = 2 })
       c:set(0, 0)
-      local before = c.cells[1][1]
       c:roll(0, 0)
-      assert.are.equal(before, c.cells[1][1])
+      assert.are.same(
+        { "⠁⠀",
+          "⠀⠀" },
+        render_lines(c)
+      )
     end)
 
 
     it("applies row and col rolls together", function()
+      -- set(0,0)→bit1 in cell[1][1]; after roll(1,1) wraps to cell[2][2]
       local c = Canvas({ width = 2, height = 2 })
-      c:set(0, 0)  -- cells[1][1]
-      local original = c.cells[1][1]
+      c:set(0, 0)
       c:roll(1, 1)
-      assert.are.equal(original, c.cells[2][2])  -- wrapped down+right
+      assert.are.same(
+        { "⠀⠀",
+          "⠀⠁" },
+        render_lines(c)
+      )
     end)
 
 
@@ -747,72 +787,65 @@ describe("terminal.ui.canvas", function()
     describe("line()", function()
 
       it("draws a horizontal line", function()
-        -- (0,0)→(3,0): pixels (0,0),(1,0) in cell (1,1); (2,0),(3,0) in cell (1,2)
-        -- col=0,row=0,bit=1 and col=1,row=0,bit=8 → braille(1+8) in each cell
+        -- (0,0)→(3,0): both braille cells get left+right top-row dots lit
         local c = Canvas({ width = 2, height = 1 })
         c:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0 })
-        assert.are.equal(braille(1 + 8), c.cells[1][1])
-        assert.are.equal(braille(1 + 8), c.cells[1][2])
+        assert.are.same({ "⠉⠉" }, render_lines(c))
       end)
 
 
       it("draws a vertical line", function()
-        -- (0,0)→(0,7): col=0, all 4 left-column bits set in each of 2 cell rows
-        -- bits 1+2+4+64 = 71 (rows 0-3 of the left dot column)
+        -- (0,0)→(0,7): left dot column fully lit in both cell rows
         local c = Canvas({ width = 1, height = 2 })
         c:line({ x1 = 0, y1 = 0, x2 = 0, y2 = 7 })
-        assert.are.equal(braille(1 + 2 + 4 + 64), c.cells[1][1])
-        assert.are.equal(braille(1 + 2 + 4 + 64), c.cells[2][1])
+        assert.are.same(
+          { "⡇",
+            "⡇" },
+          render_lines(c)
+        )
       end)
 
 
       it("draws a diagonal line", function()
-        -- (0,0)→(3,3): Bresenham gives (0,0),(1,1),(2,2),(3,3)
-        -- cells[1][1]: (0,0)=bit1, (1,1)=bit16 → braille(17)
-        -- cells[1][2]: (2,2)=bit4, (3,3)=bit128 → braille(132)
+        -- (0,0)→(3,3): Bresenham visits (0,0),(1,1),(2,2),(3,3)
         local c = Canvas({ width = 2, height = 1 })
         c:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 3 })
-        assert.are.equal(braille(1 + 16),  c.cells[1][1])
-        assert.are.equal(braille(4 + 128), c.cells[1][2])
+        assert.are.same({ "⠑⢄" }, render_lines(c))
       end)
 
 
       it("draws the same pixels regardless of direction", function()
-        -- (3,3)→(0,0) must produce identical cells to (0,0)→(3,3)
         local forward  = Canvas({ width = 2, height = 1 })
         local reversed = Canvas({ width = 2, height = 1 })
         forward:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 3 })
         reversed:line({ x1 = 3, y1 = 3, x2 = 0, y2 = 0 })
-        assert.are.equal(forward.cells[1][1], reversed.cells[1][1])
-        assert.are.equal(forward.cells[1][2], reversed.cells[1][2])
+        assert.are.same(render_lines(forward), render_lines(reversed))
       end)
 
 
       it("draws a single-pixel line (x1==x2, y1==y2)", function()
-        -- (0,0)→(0,0): only pixel (0,0), col=0,row=0,bit=1 → braille(1)
         local c = Canvas({ width = 1, height = 1 })
         c:line({ x1 = 0, y1 = 0, x2 = 0, y2 = 0 })
-        assert.are.equal(braille(1), c.cells[1][1])
+        assert.are.same({ "⠁" }, render_lines(c))
       end)
 
 
       it("erases pixels when the erase flag is set", function()
-        local c = Canvas({ width = 2, height = 1 })
-        c:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0 })
-        assert.are_not.equal(BLANK, c.cells[1][1])
-        assert.are_not.equal(BLANK, c.cells[1][2])
+        -- Inverted canvas (starts fully lit) makes the erase directly visible.
+        local c = Canvas({ width = 2, height = 1, invert = true })
         c:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0, erase = true })
-        assert.are.equal(BLANK, c.cells[1][1])
-        assert.are.equal(BLANK, c.cells[1][2])
+        assert.are.same({ "⣶⣶" }, render_lines(c))
+        c:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0 })
+        assert.are.same({ "⣿⣿" }, render_lines(c))
       end)
 
 
       it("ignores the out-of-bounds portion of a line", function()
-        -- line from inside to well outside; in-bounds pixels must be set, no error
+        -- Line from inside to well outside; in-bounds pixels are still set.
+        -- The 1×1 canvas is 2×4 physical pixels; the diagonal sets (0,0) and (1,1).
         local c = Canvas({ width = 1, height = 1 })
         assert.has_no_error(function() c:line({ x1 = 0, y1 = 0, x2 = 20, y2 = 20 }) end)
-        -- pixel (0,0) is in-bounds and must be set
-        assert.are_not.equal(BLANK, c.cells[1][1])
+        assert.are.same({ "⠑" }, render_lines(c))
       end)
 
     end)
@@ -822,53 +855,56 @@ describe("terminal.ui.canvas", function()
     describe("circle()", function()
 
       it("handles radius zero (single pixel)", function()
-        -- circle(cx=0,cy=0,r=0) on 1×1: only pixel (0,0), col=0,row=0,bit=1
         local c = Canvas({ width = 1, height = 1 })
         c:circle({ x = 0, y = 0, r = 0 })
-        assert.are.equal(braille(1), c.cells[1][1])
+        assert.are.same({ "⠁" }, render_lines(c))
       end)
 
 
       it("draws a circle outline", function()
-        -- circle(cx=2,cy=4,r=1) on 3×2 (px_w=6,px_h=8); center at cells[2][2]
+        -- circle(cx=2,cy=4,r=1) on 3×2: top dot of centre cell lit above, centre
+        -- and left neighbour lit in row 2.
         local c = Canvas({ width = 3, height = 2 })
         c:circle({ x = 2, y = 4, r = 1 })
-        assert.are.equal(braille( 0), c.cells[1][1])
-        assert.are.equal(braille(64), c.cells[1][2])
-        assert.are.equal(braille( 0), c.cells[1][3])
-        assert.are.equal(braille( 8), c.cells[2][1])
-        assert.are.equal(braille(10), c.cells[2][2])
-        assert.are.equal(braille( 0), c.cells[2][3])
+        assert.are.same(
+          { "⠀⡀⠀",
+            "⠈⠊⠀" },
+          render_lines(c)
+        )
       end)
 
 
       it("fills a circle when fill is true", function()
-        -- same as outline but center cell gains the interior pixel (2,4)→bit=1: 10+1=11
+        -- same geometry; interior pixel (2,4) is additionally lit in row 2.
         local c = Canvas({ width = 3, height = 2 })
         c:circle({ x = 2, y = 4, r = 1, fill = true })
-        assert.are.equal(braille( 0), c.cells[1][1])
-        assert.are.equal(braille(64), c.cells[1][2])
-        assert.are.equal(braille( 0), c.cells[1][3])
-        assert.are.equal(braille( 8), c.cells[2][1])
-        assert.are.equal(braille(11), c.cells[2][2])  -- center pixel added
-        assert.are.equal(braille( 0), c.cells[2][3])
+        assert.are.same(
+          { "⠀⡀⠀",
+            "⠈⠋⠀" },
+          render_lines(c)
+        )
       end)
 
 
       it("erases pixels when the erase flag is set", function()
-        local c = Canvas({ width = 3, height = 2 })
-        c:circle({ x = 2, y = 4, r = 1 })
+        -- Inverted canvas makes the erase directly visible.
+        local c = Canvas({ width = 3, height = 2, invert = true })
         c:circle({ x = 2, y = 4, r = 1, erase = true })
-        for r = 1, 2 do
-          for col = 1, 3 do
-            assert.are.equal(BLANK, c.cells[r][col])
-          end
-        end
+        assert.are.same(
+          { "⣿⢿⣿",
+            "⣷⣵⣿" },
+          render_lines(c)
+        )
+        c:circle({ x = 2, y = 4, r = 1 })
+        assert.are.same(
+          { "⣿⣿⣿",
+            "⣿⣿⣿" },
+          render_lines(c)
+        )
       end)
 
 
       it("ignores out-of-bounds pixels when circle extends beyond canvas edge", function()
-        -- circle centred near edge so part of the outline falls outside
         local c = Canvas({ width = 2, height = 2 })
         assert.has_no_error(function() c:circle({ x = 0, y = 0, r = 3 }) end)
       end)
@@ -878,11 +914,6 @@ describe("terminal.ui.canvas", function()
 
 
     describe("arc()", function()
-
-      -- Helper: render canvas to a table of braille-string lines.
-      local function render_lines(c)
-        return lines(c:render({ print = true }))
-      end
 
       local pi = math.pi
 
@@ -1070,25 +1101,22 @@ describe("terminal.ui.canvas", function()
       it("draws nothing for an empty points table", function()
         local c = Canvas({ width = 2, height = 1 })
         c:polygon({ points = {} })
-        assert.are.equal(BLANK, c.cells[1][1])
-        assert.are.equal(BLANK, c.cells[1][2])
+        assert.are.same({ "⠀⠀" }, render_lines(c))
       end)
 
 
       it("draws a single dot for one point", function()
-        -- polygon({points={{0,0}}}) on 1×1: pixel (0,0), col=0,row=0,bit=1
         local c = Canvas({ width = 1, height = 1 })
         c:polygon({ points = {{ 0, 0 }} })
-        assert.are.equal(braille(1), c.cells[1][1])
+        assert.are.same({ "⠁" }, render_lines(c))
       end)
 
 
       it("draws a line for two points", function()
-        -- polygon({points={{0,0},{3,0}}}) = horizontal line, same as line() test
+        -- polygon with 2 points is equivalent to a line()
         local c = Canvas({ width = 2, height = 1 })
         c:polygon({ points = {{ 0, 0 }, { 3, 0 }} })
-        assert.are.equal(braille(9), c.cells[1][1])
-        assert.are.equal(braille(9), c.cells[1][2])
+        assert.are.same({ "⠉⠉" }, render_lines(c))
       end)
 
 
@@ -1096,59 +1124,54 @@ describe("terminal.ui.canvas", function()
         -- triangle (0,0),(3,0),(0,3) on 2×1; interior pixel (1,1) NOT set
         local c = Canvas({ width = 2, height = 1 })
         c:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
-        assert.are.equal(braille(111), c.cells[1][1])
-        assert.are.equal(braille( 11), c.cells[1][2])
+        assert.are.same({ "⡯⠋" }, render_lines(c))
       end)
 
 
       it("fills a polygon when fill is true", function()
-        -- same triangle; interior pixel (1,1)→bit=16 added: 111+16=127
+        -- same triangle; interior pixel (1,1) additionally lit
         local c = Canvas({ width = 2, height = 1 })
         c:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }}, fill = true })
-        assert.are.equal(braille(127), c.cells[1][1])
-        assert.are.equal(braille( 11), c.cells[1][2])
+        assert.are.same({ "⡿⠋" }, render_lines(c))
       end)
 
 
       it("erases pixels when the erase flag is set", function()
-        local c = Canvas({ width = 2, height = 1 })
-        c:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
+        -- Inverted canvas makes the erase directly visible.
+        local c = Canvas({ width = 2, height = 1, invert = true })
         c:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }}, erase = true })
-        assert.are.equal(BLANK, c.cells[1][1])
-        assert.are.equal(BLANK, c.cells[1][2])
+        assert.are.same({ "⢐⣴" }, render_lines(c))
+        c:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
+        assert.are.same({ "⣿⣿" }, render_lines(c))
       end)
 
 
       it("ignores out-of-bounds pixels when polygon extends beyond canvas edge", function()
-        -- triangle with one vertex well outside the canvas
+        -- Triangle with vertices outside; in-bounds pixels along each edge are still drawn.
+        -- The 1×1 canvas is 2×4 physical pixels; edges through (0,0)–(1,0) and (0,0)–(0,3) are set.
         local c = Canvas({ width = 1, height = 1 })
         assert.has_no_error(function() c:polygon({ points = {{ 0, 0 }, { 20, 0 }, { 0, 20 }} }) end)
-        -- the in-bounds vertex (0,0) must still be drawn
-        assert.are_not.equal(BLANK, c.cells[1][1])
+        assert.are.same({ "⡏" }, render_lines(c))
       end)
 
 
       it("open=true does not draw the closing edge", function()
-        -- triangle (0,0),(3,0),(0,3): closed draws 3 edges; open draws only 2
+        -- closed draws 3 edges; open skips the (0,3)→(0,0) closing edge
         local closed = Canvas({ width = 2, height = 1 })
         closed:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
-
         local opened = Canvas({ width = 2, height = 1 })
         opened:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }}, open = true })
-
-        -- the closing edge (0,3)→(0,0) sets pixels in cell[1][1] that open skips
-        assert.are_not.equal(closed.cells[1][1], opened.cells[1][1])
+        assert.are.same({ "⡯⠋" }, render_lines(closed))
+        assert.are.same({ "⡩⠋" }, render_lines(opened))
       end)
 
 
       it("open=true with two points draws a single line (same as closed)", function()
-        -- for 2 points open and closed are identical: one segment
         local c_open   = Canvas({ width = 2, height = 1 })
         local c_closed = Canvas({ width = 2, height = 1 })
         c_open:polygon({ points = {{ 0, 0 }, { 3, 0 }}, open = true })
         c_closed:polygon({ points = {{ 0, 0 }, { 3, 0 }} })
-        assert.are.equal(c_closed.cells[1][1], c_open.cells[1][1])
-        assert.are.equal(c_closed.cells[1][2], c_open.cells[1][2])
+        assert.are.same(render_lines(c_closed), render_lines(c_open))
       end)
 
 

--- a/spec/71-canvasviewport_spec.lua
+++ b/spec/71-canvasviewport_spec.lua
@@ -1,13 +1,10 @@
 local helpers = require "spec.helpers"
 local lines = require("pl.stringx").splitlines
 
--- Mirror of canvas's internal braille() encoder, for computing expected cell values.
-local function braille(i)
-  return string.char(226, 160 + math.floor(i / 64), 128 + (i % 64))
+
+local function render_lines(c)
+  return lines(c:render({ print = true }))
 end
-
-local BLANK = braille(0)
-
 
 
 describe("terminal.ui.canvasviewport", function()
@@ -143,13 +140,11 @@ describe("terminal.ui.canvasviewport", function()
     -- Virtual: 4x4, stretch → sx=1, sy=1 (1:1 mapping)
 
     it("set maps a virtual pixel to the correct canvas pixel", function()
+      -- virtual (2,1) → physical (2,1) → cell_col=2, dot_col=0, dot_row=1, bit=2
       local c = Canvas({ width = 2, height = 1 })  -- px: 4x4
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
-      -- virtual (2, 1): physical (2, 1) → cell_col=floor(2/2)+1=2, cell_row=1
-      --   dot col=2%2=0, row=1%4=1 → bit=2 → braille(2)
       vp:set(2, 1)
-      assert.are.equal(BLANK,     c.cells[1][1])
-      assert.are.equal(braille(2), c.cells[1][2])
+      assert.are.same({ "⠀⠂" }, render_lines(c))
     end)
 
 
@@ -157,34 +152,30 @@ describe("terminal.ui.canvasviewport", function()
       local c = Canvas({ width = 2, height = 1 })  -- px: 4x4
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
       vp:set(2, 1)
-      assert.are_not.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠂" }, render_lines(c))
       vp:unset(2, 1)
-      assert.are.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
 
     it("set applies scale factor correctly", function()
-      -- Canvas 2x1 = 4px x 4px, virtual 8x8, stretch → sx=0.5, sy=0.5
-      -- virtual (4, 0) → physical (floor(4*0.5), floor(0*0.5)) = (2, 0)
-      -- cell_col=floor(2/2)+1=2, cell_row=1; dot col=0, row=0 → bit=1 → braille(1)
+      -- Canvas 2x1 = 4px x 4px, virtual 8x8, stretch → sx=sy=0.5
+      -- virtual (4,0) → physical (floor(4*0.5)=2, 0) → cell_col=2, dot_col=0, dot_row=0, bit=1
       local c = Canvas({ width = 2, height = 1 })  -- px: 4x4
       local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
       vp:set(4, 0)
-      assert.are.equal(BLANK,     c.cells[1][1])
-      assert.are.equal(braille(1), c.cells[1][2])
+      assert.are.same({ "⠀⠁" }, render_lines(c))
     end)
 
 
     it("fit mode applies centering offset for the non-limiting axis", function()
       -- Canvas 2x1 = 4px wide x 4px tall, virtual 4x2
-      -- fit: x_scale=4/4=1.0, y_scale=4/2=2.0 → s=min=1.0
-      -- center: ox=floor((4-4*1)/2)=0, oy=floor((4-2*1)/2)=1
-      -- virtual (0, 0) → physical (floor(0*1)+0, floor(0*1)+1) = (0, 1)
-      -- cell_col=1, cell_row=1; dot col=0, row=1%4=1 → bit=2 → braille(2)
+      -- fit: s=min(4/4, 4/2)=1.0; center: oy=floor((4-2*1)/2)=1
+      -- virtual (0,0) → physical (0, 0+1=1) → cell_col=1, dot_col=0, dot_row=1, bit=2
       local c = Canvas({ width = 2, height = 1 })  -- px: 4x4
       local vp = CanvasViewport({ canvas = c, width = 4, height = 2, scale_mode = "fit", anchor = "center" })
       vp:set(0, 0)
-      assert.are.equal(braille(2), c.cells[1][1])
+      assert.are.same({ "⠂⠀" }, render_lines(c))
     end)
 
 
@@ -195,7 +186,7 @@ describe("terminal.ui.canvasviewport", function()
       assert.has_no_error(function() vp:set( 0, -1) end)
       assert.has_no_error(function() vp:set(99,  0) end)
       assert.has_no_error(function() vp:set( 0, 99) end)
-      assert.are.equal(BLANK, c.cells[1][1])
+      assert.are.same({ "⠀" }, render_lines(c))
     end)
 
   end)
@@ -206,24 +197,21 @@ describe("terminal.ui.canvasviewport", function()
 
     it("draws a horizontal line in virtual space", function()
       -- Canvas 2x1 = 4x4px, virtual 4x4, stretch 1:1
-      -- line (0,0)→(3,0): same as canvas:line({x1=0,y1=0,x2=3,y2=0})
-      -- each cell gets col=0,row=0,bit=1 and col=1,row=0,bit=8 → braille(9)
+      -- line (0,0)→(3,0): each cell gets dot_col=0,dot_row=0,bit=1 and dot_col=1,bit=8 → bits 1+8=9 → "⠉"
       local c = Canvas({ width = 2, height = 1 })
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
       vp:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0 })
-      assert.are.equal(braille(9), c.cells[1][1])
-      assert.are.equal(braille(9), c.cells[1][2])
+      assert.are.same({ "⠉⠉" }, render_lines(c))
     end)
 
 
     it("applies scale to endpoints", function()
       -- Canvas 2x1 = 4x4px, virtual 8x8, stretch → sx=sy=0.5
-      -- line (0,0)→(6,0): physical (0,0)→(3,0), same as 1:1 test above
+      -- line (0,0)→(6,0): physical (0,0)→(3,0), same result as 1:1 test above
       local c = Canvas({ width = 2, height = 1 })
       local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
       vp:line({ x1 = 0, y1 = 0, x2 = 6, y2 = 0 })
-      assert.are.equal(braille(9), c.cells[1][1])
-      assert.are.equal(braille(9), c.cells[1][2])
+      assert.are.same({ "⠉⠉" }, render_lines(c))
     end)
 
 
@@ -232,8 +220,7 @@ describe("terminal.ui.canvasviewport", function()
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
       vp:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0 })
       vp:line({ x1 = 0, y1 = 0, x2 = 3, y2 = 0, erase = true })
-      assert.are.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
   end)
@@ -245,7 +232,6 @@ describe("terminal.ui.canvasviewport", function()
     it("transforms centre and radii", function()
       -- Canvas 2x1 = 4x4px, virtual 8x8, stretch → sx=sy=0.5
       -- ellipse centre (4,4), rx=2, ry=2 → physical centre (2,2), rx=1, ry=1
-      -- same as canvas:ellipse({x=2,y=2,rx=1,ry=1}) = canvas:circle({x=2,y=2,r=1})
       local ref = Canvas({ width = 2, height = 1 })
       ref:circle({ x = 2, y = 2, r = 1 })
 
@@ -253,17 +239,13 @@ describe("terminal.ui.canvasviewport", function()
       local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
       vp:ellipse({ x = 4, y = 4, rx = 2, ry = 2 })
 
-      for r = 1, ref.rows do
-        for col = 1, ref.cols do
-          assert.are.equal(ref.cells[r][col], c.cells[r][col])
-        end
-      end
+      assert.are.same(render_lines(ref), render_lines(c))
     end)
 
 
     it("stretch mode scales rx and ry independently", function()
-      -- Canvas 4x2 = 8px x 8px, virtual 4x8, stretch → sx=8/4=2, sy=8/8=1
-      -- ellipse centre (2,4), rx=1, ry=1 → physical centre(4,4), rx=2, ry=1 (becomes ellipse)
+      -- Canvas 4x2 = 8x8px, virtual 4x8, stretch → sx=2, sy=1
+      -- ellipse centre (2,4), rx=1, ry=1 → physical centre (4,4), rx=2, ry=1
       local ref = Canvas({ width = 4, height = 2 })
       ref:ellipse({ x = 4, y = 4, rx = 2, ry = 1 })
 
@@ -271,31 +253,18 @@ describe("terminal.ui.canvasviewport", function()
       local vp = CanvasViewport({ canvas = c, width = 4, height = 8, scale_mode = "stretch" })
       vp:ellipse({ x = 2, y = 4, rx = 1, ry = 1 })
 
-      for r = 1, ref.rows do
-        for col = 1, ref.cols do
-          assert.are.equal(ref.cells[r][col], c.cells[r][col])
-        end
-      end
+      assert.are.same(render_lines(ref), render_lines(c))
     end)
 
 
     it("erase flag is forwarded to canvas", function()
-      local c = Canvas({ width = 2, height = 1 })
+      -- Inverted canvas makes the erase directly visible.
+      local c = Canvas({ width = 2, height = 1, invert = true })
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
-      vp:ellipse({ x = 2, y = 2, rx = 1, ry = 1 })
-      local had_pixels = false
-      for _, row in ipairs(c.cells) do
-        for _, cell in ipairs(row) do
-          if cell ~= BLANK then had_pixels = true end
-        end
-      end
-      assert.is_true(had_pixels)
       vp:ellipse({ x = 2, y = 2, rx = 1, ry = 1, erase = true })
-      for r = 1, c.rows do
-        for col = 1, c.cols do
-          assert.are.equal(BLANK, c.cells[r][col])
-        end
-      end
+      assert.are_not.same({ "⣿⣿" }, render_lines(c))
+      vp:ellipse({ x = 2, y = 2, rx = 1, ry = 1 })
+      assert.are.same({ "⣿⣿" }, render_lines(c))
     end)
 
   end)
@@ -305,7 +274,7 @@ describe("terminal.ui.canvasviewport", function()
   describe("circle()", function()
 
     it("delegates to ellipse with equal radii", function()
-      -- circle with r=2 should produce the same result as ellipse with rx=ry=2
+      -- circle(r=4) should produce identical pixels to ellipse(rx=4, ry=4)
       local c1 = Canvas({ width = 3, height = 2 })
       local vp1 = CanvasViewport({ canvas = c1, width = 12, height = 8, scale_mode = "stretch" })
       vp1:circle({ x = 6, y = 4, r = 4 })
@@ -314,11 +283,7 @@ describe("terminal.ui.canvasviewport", function()
       local vp2 = CanvasViewport({ canvas = c2, width = 12, height = 8, scale_mode = "stretch" })
       vp2:ellipse({ x = 6, y = 4, rx = 4, ry = 4 })
 
-      for r = 1, c1.rows do
-        for col = 1, c1.cols do
-          assert.are.equal(c1.cells[r][col], c2.cells[r][col])
-        end
-      end
+      assert.are.same(render_lines(c1), render_lines(c2))
     end)
 
   end)
@@ -330,7 +295,6 @@ describe("terminal.ui.canvasviewport", function()
     it("transforms all points before drawing", function()
       -- Canvas 2x1 = 4x4px, virtual 8x8, stretch → sx=sy=0.5
       -- polygon points (0,0),(6,0),(0,6) → physical (0,0),(3,0),(0,3)
-      -- same as canvas:polygon({points={{0,0},{3,0},{0,3}}})
       local ref = Canvas({ width = 2, height = 1 })
       ref:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
 
@@ -338,15 +302,12 @@ describe("terminal.ui.canvasviewport", function()
       local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
       vp:polygon({ points = {{ 0, 0 }, { 6, 0 }, { 0, 6 }} })
 
-      for r = 1, ref.rows do
-        for col = 1, ref.cols do
-          assert.are.equal(ref.cells[r][col], c.cells[r][col])
-        end
-      end
+      assert.are.same(render_lines(ref), render_lines(c))
     end)
 
 
     it("open and fill flags are forwarded to canvas", function()
+      -- closed triangle (0,0),(3,0),(0,3) draws 3 edges; open skips the closing edge
       local c_open   = Canvas({ width = 2, height = 1 })
       local c_closed = Canvas({ width = 2, height = 1 })
       local vp_open   = CanvasViewport({ canvas = c_open,   width = 4, height = 4, scale_mode = "stretch" })
@@ -355,8 +316,8 @@ describe("terminal.ui.canvasviewport", function()
       vp_open:polygon({ points   = {{ 0, 0 }, { 3, 0 }, { 0, 3 }}, open = true })
       vp_closed:polygon({ points = {{ 0, 0 }, { 3, 0 }, { 0, 3 }} })
 
-      -- open polygon skips the closing edge so the two canvases differ
-      assert.are_not.equal(c_open.cells[1][1], c_closed.cells[1][1])
+      assert.are.same({ "⡩⠋" }, render_lines(c_open))
+      assert.are.same({ "⡯⠋" }, render_lines(c_closed))
     end)
 
 
@@ -364,8 +325,7 @@ describe("terminal.ui.canvasviewport", function()
       local c = Canvas({ width = 2, height = 1 })
       local vp = CanvasViewport({ canvas = c, width = 4, height = 4, scale_mode = "stretch" })
       vp:polygon({ points = {} })
-      assert.are.equal(BLANK, c.cells[1][1])
-      assert.are.equal(BLANK, c.cells[1][2])
+      assert.are.same({ "⠀⠀" }, render_lines(c))
     end)
 
   end)
@@ -375,10 +335,6 @@ describe("terminal.ui.canvasviewport", function()
   describe("arc()", function()
 
     local pi = math.pi
-
-    local function render_lines(c)
-      return lines(c:render({ print = true }))
-    end
 
 
     it("transforms centre and radii into physical pixel space", function()
@@ -438,14 +394,13 @@ describe("terminal.ui.canvasviewport", function()
       local c1 = Canvas({ width = 2, height = 1 })
       local vp = CanvasViewport({ canvas = c1, width = 4, height = 4, scale_mode = "stretch" })
       vp:set(0, 0)
-      assert.are_not.equal(BLANK, c1.cells[1][1])
+      assert.are.same({ "⠁⠀" }, render_lines(c1))
 
       local c2 = Canvas({ width = 2, height = 1 })
       vp:set_canvas(c2)
       vp:set(0, 0)
-      assert.are_not.equal(BLANK, c2.cells[1][1])
-      -- c1 was not touched by the second set
-      assert.are.equal(BLANK, c1.cells[1][2])
+      assert.are.same({ "⠁⠀" }, render_lines(c2))
+      assert.are.same({ "⠁⠀" }, render_lines(c1))  -- c1 unchanged: only [1][1] was ever set
     end)
 
 

--- a/spec/71-canvasviewport_spec.lua
+++ b/spec/71-canvasviewport_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local lines = require("pl.stringx").splitlines
 
 -- Mirror of canvas's internal braille() encoder, for computing expected cell values.
 local function braille(i)
@@ -365,6 +366,66 @@ describe("terminal.ui.canvasviewport", function()
       vp:polygon({ points = {} })
       assert.are.equal(BLANK, c.cells[1][1])
       assert.are.equal(BLANK, c.cells[1][2])
+    end)
+
+  end)
+
+
+
+  describe("arc()", function()
+
+    local pi = math.pi
+
+    local function render_lines(c)
+      return lines(c:render({ print = true }))
+    end
+
+
+    it("transforms centre and radii into physical pixel space", function()
+      -- Canvas 2x1 = 4x4px, virtual 8x8, stretch → sx=sy=0.5
+      -- arc at virtual (4,4), rx=2, ry=2, 0..pi/2
+      -- physical: centre (2,2), rx=1, ry=1, same angles
+      local c = Canvas({ width = 2, height = 1 })
+      local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
+      vp:arc({ x = 4, y = 4, rx = 2, ry = 2, angle_start = 0, angle_end = pi / 2 })
+      assert.are.same({ "⠀⣠" }, render_lines(c))
+    end)
+
+
+    it("angles are not scaled by the scale factor", function()
+      -- Canvas 2x1 = 4x4px, virtual 8x8, stretch → sx=sy=0.5
+      -- half arc 0..pi: if angles were scaled by sx the arc would be 0..pi/2 and
+      -- the left endpoint pixel would be absent; a full half-arc includes it.
+      local c = Canvas({ width = 2, height = 1 })
+      local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
+      vp:arc({ x = 4, y = 4, rx = 2, ry = 2, angle_start = 0, angle_end = pi })
+      assert.are.same({ "⠠⣠" }, render_lines(c))
+    end)
+
+
+    it("stretch mode scales rx and ry independently, leaving angles unchanged", function()
+      -- Canvas 4x2 = 8x8px, virtual 4x8, stretch → sx=2, sy=1
+      -- arc at virtual (2,4), rx=1, ry=1, 0..pi/2
+      -- physical: centre (4,4), rx=2, ry=1 — circular arc maps to elliptic arc
+      local c = Canvas({ width = 4, height = 2 })
+      local vp = CanvasViewport({ canvas = c, width = 4, height = 8, scale_mode = "stretch" })
+      vp:arc({ x = 2, y = 4, rx = 1, ry = 1, angle_start = 0, angle_end = pi / 2 })
+      assert.are.same(
+        { "⠀⠀⠀⠀",
+          "⠀⠀⠒⠁" },
+        render_lines(c)
+      )
+    end)
+
+
+    it("erase flag is forwarded to canvas", function()
+      -- Use an inverted canvas so erasing is directly visible as holes in solid background.
+      local c = Canvas({ width = 2, height = 1, invert = true })
+      local vp = CanvasViewport({ canvas = c, width = 8, height = 8, scale_mode = "stretch" })
+      vp:arc({ x = 4, y = 4, rx = 2, ry = 2, angle_start = 0, angle_end = pi / 2, erase = true })
+      assert.are.same({ "⣿⠟" }, render_lines(c))
+      vp:arc({ x = 4, y = 4, rx = 2, ry = 2, angle_start = 0, angle_end = pi / 2 })
+      assert.are.same({ "⣿⣿" }, render_lines(c))
     end)
 
   end)

--- a/src/terminal/ui/canvas.lua
+++ b/src/terminal/ui/canvas.lua
@@ -539,6 +539,68 @@ end
 
 
 
+--- Draw an arc (a portion of an ellipse outline).
+-- Walks the ellipse parametrically from `angle_start` to `angle_end` (both in radians),
+-- always in the direction of increasing angle.
+--
+-- **Angle convention:** Because the canvas origin is top-left and y increases downward,
+-- positive angles go clockwise on screen: 0 points right, pi/2 points down, pi points
+-- left, 3*pi/2 points up. This is the opposite of the standard mathematical convention.
+--
+-- **Range:** `angle_end` must be >= `angle_start`. For a full ellipse use
+-- `angle_end = angle_start + 2*math.pi`. Ranges larger than `2*pi` are accepted but
+-- cause the arc to be traced more than once; since `set`/`unset` are idempotent this
+-- produces the correct pixels but wastes proportional compute time.
+-- @tparam table opts
+-- @tparam integer opts.x centre pixel column, 0-based
+-- @tparam integer opts.y centre pixel row, 0-based
+-- @tparam integer opts.rx horizontal radius in pixels
+-- @tparam integer opts.ry vertical radius in pixels
+-- @tparam number opts.angle_start start angle in radians
+-- @tparam number opts.angle_end end angle in radians (must be >= angle_start)
+-- @tparam[opt=false] boolean opts.erase if truthy, unset pixels instead of setting them
+function Canvas:arc(opts)
+  local cx = opts.x
+  local cy = opts.y
+  local rx = floor(opts.rx)
+  local ry = floor(opts.ry)
+  local a1 = opts.angle_start
+  local a2 = opts.angle_end
+  local op = opts.erase and self.unset or self.set
+
+  if rx < 0 or ry < 0 then
+    error("rx and ry must be >= 0", 2)
+  end
+
+  if a2 < a1 then
+    error("angle_end must be >= angle_start", 2)
+  end
+
+  if rx == 0 and ry == 0 then
+    op(self, cx, cy)
+    return
+  end
+
+  local step = 1.0 / math.max(rx, ry)
+  local px, py  -- previous pixel, for deduplication
+  local theta = a1
+
+  while true do
+    -- clamp to a2 on the final step to always plot the exact endpoint
+    local t = theta < a2 and theta or a2
+    local x = floor(cx + rx * math.cos(t) + 0.5)
+    local y = floor(cy + ry * math.sin(t) + 0.5)
+    if x ~= px or y ~= py then
+      op(self, x, y)
+      px, py = x, y
+    end
+    if t >= a2 then break end
+    theta = theta + step
+  end
+end
+
+
+
 --- Draw a polygon from an array of `{x, y}` points.
 -- 1 point draws a dot, 2 points draw a line, 3+ points draw a closed polygon by default.
 -- @tparam table opts

--- a/src/terminal/ui/canvasviewport.lua
+++ b/src/terminal/ui/canvasviewport.lua
@@ -263,6 +263,35 @@ end
 
 
 
+--- Draw an arc using virtual-space coordinates.
+-- Scales the centre and radii into physical canvas pixels, then delegates to `Canvas:arc`.
+-- Angles are passed through unchanged; they describe the same geometric direction
+-- regardless of scale.
+--
+-- Note: angles are drawn clockwise, see `Canvas:arc` for details.
+-- @tparam table opts
+-- @tparam number opts.x Centre virtual pixel column, 0-based.
+-- @tparam number opts.y Centre virtual pixel row, 0-based.
+-- @tparam number opts.rx Horizontal radius in virtual pixels.
+-- @tparam number opts.ry Vertical radius in virtual pixels.
+-- @tparam number opts.angle_start Start angle in radians.
+-- @tparam number opts.angle_end End angle in radians (must be >= angle_start).
+-- @tparam[opt=false] boolean opts.erase If truthy, unset pixels instead of setting them.
+function CanvasViewport:arc(opts)
+  local sx, sy, ox, oy = self._sx, self._sy, self._ox, self._oy
+  self._canvas:arc({
+    x = floor(opts.x * sx) + ox,
+    y = floor(opts.y * sy) + oy,
+    rx = floor(opts.rx * sx),
+    ry = floor(opts.ry * sy),
+    angle_start = opts.angle_start,
+    angle_end = opts.angle_end,
+    erase = opts.erase,
+  })
+end
+
+
+
 --- Draw a polygon from an array of virtual-space `{x, y}` points.
 -- 1 point draws a dot, 2 points draw a line, 3+ points draw a closed polygon by default.
 -- @tparam table opts


### PR DESCRIPTION
Adds Canvas:arc() -- a parametric walk from angle_start to angle_end that
draws at physical pixel resolution, eliminating the gap problem that arose
when using vp:set() per virtual pixel at large scales.

CanvasViewport:arc() is the matching wrapper: centre and radii are scaled
into physical pixels while angles pass through unchanged.

The canvas example dashed_circle is reworked to use arc(), replacing the
manual angle-stepping loop with one vp:arc() call per dash segment.

Tests added to 70-canvas_spec and 71-canvasviewport_spec, using the
render-to-braille-string-array style consistent with the graph spec.

Also; refactored many tests to be string-array assertions, such that the tests are easier to reason about.