### PR TITLE
refactor(canvas): move canvas files into its own subdir

### DIFF
--- a/doc_topics/01-introduction.md
+++ b/doc_topics/01-introduction.md
@@ -23,6 +23,7 @@ configuring the terminal and abstractions over ANSI codes;
 
   - CLI widgets, see the `CLI` classes like `cli.Select` and `cli.Prompt`.
   - Fullscreen UIs, see the `UI` classes like `ui.panel.Screen` and `ui.panel.Bar`.
+  - Pixel graphics, see the `Canvas` classes: `Canvas`, `canvas.Viewport`, and `canvas.TimeSeriesGraph`.
 
 
 ## 1.2 initialization & shutdown

--- a/doc_topics/04-canvas.md
+++ b/doc_topics/04-canvas.md
@@ -1,0 +1,56 @@
+# 4. Canvas (braille pixel graphics)
+
+The `terminal.canvas` module family provides a pixel-level drawing surface built on Unicode
+Braille characters. Each terminal cell holds one braille character (U+2800–U+28FF), which
+encodes a 2×4 dot grid — so a canvas that is **W columns × H rows** in terminal space exposes
+**2W × 4H pixels**.
+
+Three classes build on each other:
+
+- `Canvas` — the raw pixel grid and all drawing primitives.
+- `canvas.Viewport` — maps a fixed virtual coordinate space onto a canvas with scaling and alignment.
+- `canvas.TimeSeriesGraph` — a ready-made scrolling data graph drawn on a canvas.
+
+## 4.1 Canvas
+
+A `Canvas` owns a grid of braille cells. Pixel coordinates are **0-based**, origin at the
+top-left, x increasing right, y increasing down. Drawing outside the bounds is silently
+ignored.
+
+The canvas can be rendered with `render()`. Without options, cursor movement sequences are
+included so the cursor returns to the top-left of the block after rendering — suitable for
+use inside a TUI layout. Pass `print = true` to get plain newline-separated output instead.
+
+See the `Canvas` class reference for all drawing primitives (`line`, `ellipse`, `circle`,
+`arc`, `polygon`) and canvas management methods (`clear`, `resize`, `scroll`, `roll`).
+
+## 4.2 canvas.Viewport
+
+Drawing directly in physical pixels is inconvenient when the canvas size changes (e.g. on
+terminal resize). `canvas.Viewport` solves this by providing a **fixed virtual coordinate
+space** that it maps to the underlying canvas via a linear transform.
+
+Three scale modes control what happens when the virtual and physical aspect ratios differ:
+
+- `stretch` — x and y scaled independently; fills the canvas exactly, may distort.
+- `fit` — uniform scale; fits inside the canvas, leaving blank letterbox/pillarbox bands.
+- `fill` — uniform scale; fills the canvas, clipping content outside the bounds.
+
+The `anchor` option (`center` or `top_left`) positions the virtual space within any blank
+bands that appear in `fit` mode.
+
+On terminal resize, call `set_canvas` with a new canvas and re-issue all drawing calls.
+`canvas.Viewport` exposes the same drawing primitives as `Canvas`, using virtual coordinates.
+
+See `examples/canvas.lua` for a working demo.
+
+## 4.3 canvas.TimeSeriesGraph
+
+`canvas.TimeSeriesGraph` renders a scrolling data plot. It manages a sliding sample window,
+Y-axis bounds, tick marks, and labels. Push values with `push()`, then either draw onto an
+existing canvas with `draw(canvas)` or let it create one internally via `render({ cols, rows })`.
+
+When `min`/`max` are omitted, the range expands dynamically, snapping to the nearest "nice"
+number (1/2/5 × 10ⁿ).
+
+See `examples/graph.lua` for a working demo.

--- a/examples/canvas.lua
+++ b/examples/canvas.lua
@@ -1,6 +1,6 @@
 local t = require "terminal"
-local Canvas = require "terminal.ui.canvas"
-local CanvasViewport = require "terminal.ui.canvasviewport"
+local Canvas = require "terminal.canvas"
+local CanvasViewport = require "terminal.canvas.viewport"
 
 -- Virtual coordinate space: matches the original Lua-logo geometry
 -- (original canvas was 60×30 cells → 120×120 pixels)

--- a/examples/graph.lua
+++ b/examples/graph.lua
@@ -7,7 +7,7 @@
 -- Press any key to quit.
 
 local t               = require "terminal"
-local TimeSeriesGraph = require "terminal.ui.timeseriesgraph"
+local TimeSeriesGraph = require "terminal.canvas.timeseriesgraph"
 
 local HISTORY_SIZE = 100   -- number of samples kept / displayed
 local INTERVAL     = 0.10  -- seconds between updates

--- a/spec/70-canvas_spec.lua
+++ b/spec/70-canvas_spec.lua
@@ -20,14 +20,14 @@ local FILLED = braille(255)  -- U+28FF, all dots on
 
 
 
-describe("terminal.ui.canvas", function()
+describe("terminal.canvas", function()
 
   local Canvas
   local position
 
   setup(function()
     local terminal = helpers.load()
-    Canvas   = require("terminal.ui.canvas")
+    Canvas   = require("terminal.canvas")
     position = terminal.cursor.position
   end)
 

--- a/spec/71-canvasviewport_spec.lua
+++ b/spec/71-canvasviewport_spec.lua
@@ -7,14 +7,14 @@ local function render_lines(c)
 end
 
 
-describe("terminal.ui.canvasviewport", function()
+describe("terminal.canvas.viewport", function()
 
   local Canvas, CanvasViewport
 
   setup(function()
     helpers.load()
-    Canvas         = require "terminal.ui.canvas"
-    CanvasViewport = require "terminal.ui.canvasviewport"
+    Canvas         = require "terminal.canvas"
+    CanvasViewport = require "terminal.canvas.viewport"
   end)
 
 

--- a/spec/72-timeseriesgraph_spec.lua
+++ b/spec/72-timeseriesgraph_spec.lua
@@ -4,7 +4,7 @@ local lines = require("pl.stringx").splitlines
 
 
 
-describe("terminal.ui.timeseriesgraph", function()
+describe("terminal.canvas.timeseriesgraph", function()
 
   local TimeSeriesGraph
   local Canvas
@@ -13,8 +13,8 @@ describe("terminal.ui.timeseriesgraph", function()
 
   setup(function()
     helpers.load()
-    TimeSeriesGraph = require "terminal.ui.timeseriesgraph"
-    Canvas = require "terminal.ui.canvas"
+    TimeSeriesGraph = require "terminal.canvas.timeseriesgraph"
+    Canvas = require "terminal.canvas"
     Sequence = require "terminal.sequence"
     strip_ansi = require("terminal.utils").strip_ansi
   end)

--- a/src/terminal/canvas/init.lua
+++ b/src/terminal/canvas/init.lua
@@ -6,7 +6,7 @@
 -- the canvas bounds is ignored (no error).
 --
 -- Example usage:
---     local Canvas = require "terminal.ui.canvas"
+--     local Canvas = require "terminal.canvas"
 --     local c = Canvas({
 --       width = 60,
 --       height = 30,

--- a/src/terminal/canvas/init.lua
+++ b/src/terminal/canvas/init.lua
@@ -13,7 +13,7 @@
 --     })
 --     c:set(10, 5)  -- set a pixel at (10, 5)
 --     print(c:render({ print = true }))  -- render the canvas for printing
--- @classmod ui.Canvas
+-- @classmod Canvas
 
 local position = require "terminal.cursor.position"
 local concat = table.concat
@@ -86,7 +86,7 @@ local Canvas = utils.class()
 -- @tparam integer opts.height Height in display rows (each row is 4 pixels tall)
 -- @tparam[opt=false] boolean opts.invert If true, cleared cells are fully lit instead of empty
 -- @usage
--- local Canvas = require "terminal.ui.canvas"
+-- local Canvas = require "terminal.canvas"
 -- local c = Canvas({
 --   width = 60,
 --   height = 30,

--- a/src/terminal/canvas/timeseriesgraph.lua
+++ b/src/terminal/canvas/timeseriesgraph.lua
@@ -13,14 +13,14 @@
 -- `min` and `max` can be omitted to make the range dynamic: it expands
 -- automatically when a pushed value falls outside the current bounds,
 -- snapping the new boundary to the nearest nice number.
--- @classmod ui.TimeSeriesGraph
+-- @classmod ui.canvas.TimeSeriesGraph
 
 local position = require "terminal.cursor.position"
 local Sequence = require "terminal.sequence"
-local Canvas = require "terminal.ui.canvas"
+local Canvas = require "terminal.canvas"
 local utils = require "terminal.utils"
 local text = require "terminal.text"
-local CVP = require "terminal.ui.canvasviewport"
+local CVP = require "terminal.canvas.viewport"
 
 
 

--- a/src/terminal/canvas/timeseriesgraph.lua
+++ b/src/terminal/canvas/timeseriesgraph.lua
@@ -13,7 +13,7 @@
 -- `min` and `max` can be omitted to make the range dynamic: it expands
 -- automatically when a pushed value falls outside the current bounds,
 -- snapping the new boundary to the nearest nice number.
--- @classmod ui.canvas.TimeSeriesGraph
+-- @classmod canvas.TimeSeriesGraph
 
 local position = require "terminal.cursor.position"
 local Sequence = require "terminal.sequence"

--- a/src/terminal/canvas/viewport.lua
+++ b/src/terminal/canvas/viewport.lua
@@ -56,7 +56,7 @@
 --     vp:line({ x1 = 0, y1 = 0, x2 = 299, y2 = 299 })  -- diagonal in virtual space
 --     -- position cursor and write c:render() as usual
 --
--- @classmod ui.canvas.Viewport
+-- @classmod canvas.Viewport
 
 local utils = require "terminal.utils"
 local floor = math.floor
@@ -69,7 +69,7 @@ local CanvasViewport = utils.class()
 
 --- Scale mode constants; `stretch`, `fit`, or `fill` determine how the virtual
 -- coordinate space is mapped to the underlying canvas when their aspect ratios do not match.
--- @field ui.CanvasViewport.scale_modes table lookup table for scale mode constants.
+-- @field canvas.Viewport.scale_modes table lookup table for scale mode constants.
 CanvasViewport.scale_modes = utils.make_lookup("scale_mode", {
   stretch = "stretch",
   fit = "fit",
@@ -83,7 +83,7 @@ CanvasViewport.scale_modes = utils.make_lookup("scale_mode", {
 -- canvas, and with `top_left` the virtual space is aligned to the top-left corner of the canvas.
 -- This has no effect when `scale_mode` is `stretch` since the virtual space always fills the canvas
 -- in that mode.
--- @field ui.CanvasViewport.anchors table lookup table for anchor constants.
+-- @field canvas.Viewport.anchors table lookup table for anchor constants.
 CanvasViewport.anchors = utils.make_lookup("anchor", {
   center = "center",
   top_left = "top_left",

--- a/src/terminal/canvas/viewport.lua
+++ b/src/terminal/canvas/viewport.lua
@@ -43,8 +43,8 @@
 -- drawing calls.
 --
 -- Example usage:
---     local Canvas = require "terminal.ui.canvas"
---     local CanvasViewport = require "terminal.ui.canvasviewport"
+--     local Canvas = require "terminal.canvas"
+--     local CanvasViewport = require "terminal.canvas.viewport"
 --
 --     -- Inside a Panel content callback, called on every render (including resize):
 --     local c = Canvas({ width = panel.inner_width, height = panel.inner_height })
@@ -56,7 +56,7 @@
 --     vp:line({ x1 = 0, y1 = 0, x2 = 299, y2 = 299 })  -- diagonal in virtual space
 --     -- position cursor and write c:render() as usual
 --
--- @classmod ui.CanvasViewport
+-- @classmod ui.canvas.Viewport
 
 local utils = require "terminal.utils"
 local floor = math.floor

--- a/src/terminal/init.lua
+++ b/src/terminal/init.lua
@@ -55,17 +55,6 @@ M._sleep = sys.sleep   -- a (optionally) non-blocking sleep function
 
 
 
---- Returns the terminal size in rows and columns.
--- Just a convenience, maps 1-on-1 to `system.termsize`.
--- @treturn[1] number number of rows
--- @treturn[1] number number of columns
--- @treturn[2] nil on error
--- @treturn[2] string error message
--- @function size
-M.size = sys.termsize
-
-
-
 --- Returns a string sequence to make the terminal beep.
 -- @treturn string ansi sequence to write to the terminal
 function M.bell_seq()
@@ -80,6 +69,17 @@ function M.bell()
   output.write(M.bell_seq())
   return true
 end
+
+
+
+--- Returns the terminal size in rows and columns.
+-- Just a convenience, maps 1-on-1 to `system.termsize`.
+-- @treturn[1] number number of rows
+-- @treturn[1] number number of columns
+-- @treturn[2] nil on error
+-- @treturn[2] string error message
+-- @function size
+M.size = sys.termsize
 
 
 

--- a/terminal-scm-1.rockspec
+++ b/terminal-scm-1.rockspec
@@ -61,9 +61,9 @@ build = {
     ["terminal.ui.panel.set"] = "src/terminal/ui/panel/set.lua",
     ["terminal.ui.panel.tab_strip"] = "src/terminal/ui/panel/tab_strip.lua",
     ["terminal.ui.panel.key_bar"] = "src/terminal/ui/panel/key_bar.lua",
-    ["terminal.ui.canvas"] = "src/terminal/ui/canvas.lua",
-    ["terminal.ui.canvasviewport"] = "src/terminal/ui/canvasviewport.lua",
-    ["terminal.ui.timeseriesgraph"] = "src/terminal/ui/timeseriesgraph.lua",
+    ["terminal.canvas"] = "src/terminal/canvas/init.lua",
+    ["terminal.canvas.viewport"] = "src/terminal/canvas/viewport.lua",
+    ["terminal.canvas.timeseriesgraph"] = "src/terminal/canvas/timeseriesgraph.lua",
   },
 
   copy_directories = {


### PR DESCRIPTION
Canvas can be used by both CLI and UI subsystems, hence we
move it into its own subfolder.