### PR TITLE
feat(panel): allow parent panel to also have a border

### DIFF
--- a/spec/20-panel_spec.lua
+++ b/spec/20-panel_spec.lua
@@ -692,10 +692,44 @@ describe("terminal.ui.panel", function()
       assert.are.equal(7, bottom_panel.height) -- remaining space
     end)
 
+
+    it("accounts for single-width border characters in inner area", function()
+      local draw = require("terminal.draw")
+      local panel = Panel {
+        content = function() end,
+        border = { format = draw.box_fmt.single }
+      }
+
+      panel:calculate_layout(1, 1, 10, 20)
+
+      -- All four edges present, each 1 column/row wide
+      assert.are.equal(2, panel.inner_row)    -- top border: +1 row
+      assert.are.equal(2, panel.inner_col)    -- left border: +1 col
+      assert.are.equal(8, panel.inner_height) -- top + bottom borders: -2 rows
+      assert.are.equal(18, panel.inner_width) -- left + right borders: -2 cols
+    end)
+
+
+    it("accounts for double-width border characters in inner area", function()
+      local draw = require("terminal.draw")
+      local fmt = draw.box_fmt.copy(draw.box_fmt.single)
+      fmt.l = "一"  -- U+4E00, display width 2
+      fmt.r = "一"
+
+      local panel = Panel {
+        content = function() end,
+        border = { format = fmt }
+      }
+
+      panel:calculate_layout(1, 1, 10, 20)
+
+      assert.are.equal(2, panel.inner_row)    -- top border: +1 row
+      assert.are.equal(8, panel.inner_height) -- top + bottom borders: -2 rows
+      assert.are.equal(3, panel.inner_col)    -- left border: +2 cols
+      assert.are.equal(16, panel.inner_width) -- left + right borders: -4 cols
+    end)
+
   end)
-
-
-
 
 
 

--- a/spec/20-panel_spec.lua
+++ b/spec/20-panel_spec.lua
@@ -552,6 +552,57 @@ describe("terminal.ui.panel", function()
       assert.are.equal(expected_name, panel.name)
     end)
 
+
+    it("accepts border configuration on divided panels", function()
+      local draw = require("terminal.draw")
+      local left_panel = Panel { content = function() end }
+      local right_panel = Panel { content = function() end }
+
+      local panel
+      assert.has_no.errors(function()
+        panel = Panel {
+          orientation = Panel.orientations.horizontal,
+          children = { left_panel, right_panel },
+          border = { format = draw.box_fmt.single, title = "Split Panel" }
+        }
+      end)
+
+      assert.is_not_nil(panel.border)
+      assert.are.equal(draw.box_fmt.single, panel.border.format)
+      assert.are.equal("Split Panel", panel.border.title)
+    end)
+
+
+    it("throws error when border has no format on divided panel", function()
+      local left_panel = Panel { content = function() end }
+      local right_panel = Panel { content = function() end }
+
+      assert.has.error(function()
+        Panel {
+          orientation = Panel.orientations.horizontal,
+          children = { left_panel, right_panel },
+          border = {}
+        }
+      end, "border.format is required when border is specified")
+    end)
+
+
+    it("derives constraints from children including border overhead for divided panels", function()
+      local draw = require("terminal.draw")
+      local left_panel = Panel { content = function() end, min_height = 3, min_width = 8 }
+      local right_panel = Panel { content = function() end, min_height = 4, min_width = 6 }
+
+      local panel = Panel {
+        orientation = Panel.orientations.horizontal,
+        children = { left_panel, right_panel },
+        border = { format = draw.box_fmt.single }
+      }
+
+      -- single border: top+bottom = 2 rows overhead, left+right = 2 cols overhead
+      assert.are.equal(6, panel:get_min_height()) -- max(3,4) + 2
+      assert.are.equal(16, panel:get_min_width())  -- 8+6 + 2
+    end)
+
   end)
 
 
@@ -729,6 +780,62 @@ describe("terminal.ui.panel", function()
       assert.are.equal(16, panel.inner_width) -- left + right borders: -4 cols
     end)
 
+
+    it("lays out children inside parent border (horizontal)", function()
+      local draw = require("terminal.draw")
+      local left_panel = Panel { content = function() end }
+      local right_panel = Panel { content = function() end }
+
+      local panel = Panel {
+        orientation = Panel.orientations.horizontal,
+        split_ratio = 0.5,
+        children = { left_panel, right_panel },
+        border = { format = draw.box_fmt.single }
+      }
+
+      panel:calculate_layout(1, 1, 10, 20)
+
+      -- Inner area: row 2, col 2, height 8, width 18 (single border on all sides)
+      -- Left child: half of inner width = 9
+      assert.are.equal(2, left_panel.row)
+      assert.are.equal(2, left_panel.col)
+      assert.are.equal(8, left_panel.height)
+      assert.are.equal(9, left_panel.width)
+      -- Right child: remaining inner width = 9
+      assert.are.equal(2, right_panel.row)
+      assert.are.equal(11, right_panel.col)  -- 2 + 9
+      assert.are.equal(8, right_panel.height)
+      assert.are.equal(9, right_panel.width)
+    end)
+
+
+    it("lays out children inside parent border (vertical)", function()
+      local draw = require("terminal.draw")
+      local top_panel = Panel { content = function() end }
+      local bottom_panel = Panel { content = function() end }
+
+      local panel = Panel {
+        orientation = Panel.orientations.vertical,
+        split_ratio = 0.5,
+        children = { top_panel, bottom_panel },
+        border = { format = draw.box_fmt.single }
+      }
+
+      panel:calculate_layout(1, 1, 10, 20)
+
+      -- Inner area: row 2, col 2, height 8, width 18 (single border on all sides)
+      -- Top child: half of inner height = 4
+      assert.are.equal(2, top_panel.row)
+      assert.are.equal(2, top_panel.col)
+      assert.are.equal(4, top_panel.height)
+      assert.are.equal(18, top_panel.width)
+      -- Bottom child: remaining inner height = 4
+      assert.are.equal(6, bottom_panel.row)  -- 2 + 4
+      assert.are.equal(2, bottom_panel.col)
+      assert.are.equal(4, bottom_panel.height)
+      assert.are.equal(18, bottom_panel.width)
+    end)
+
   end)
 
 
@@ -858,10 +965,44 @@ describe("terminal.ui.panel", function()
       assert.is_true(right_callback_called)
     end)
 
+
+    it("draws border for divided panel before rendering children", function()
+      local draw = require("terminal.draw")
+      local text_module = require("terminal.text")
+      local terminal_mod = require("terminal")
+      local clear_mod = require("terminal.clear")
+
+      local old_box = draw.box
+      local old_stack = text_module.stack
+      local old_cursor = terminal_mod.cursor
+      local old_clear_box = clear_mod.box
+
+      local box_called = false
+      draw.box = function() box_called = true end
+      text_module.stack = { push = function() end, pop = function() end }
+      terminal_mod.cursor = { position = { backup = function() end, restore = function() end, set = function() end } }
+      clear_mod.box = function() end
+
+      local left_panel = Panel { content = function() end }
+      local right_panel = Panel { content = function() end }
+      local panel = Panel {
+        orientation = Panel.orientations.horizontal,
+        children = { left_panel, right_panel },
+        border = { format = draw.box_fmt.single }
+      }
+
+      panel:calculate_layout(1, 1, 10, 20)
+      panel:render()
+
+      draw.box = old_box
+      text_module.stack = old_stack
+      terminal_mod.cursor = old_cursor
+      clear_mod.box = old_clear_box
+
+      assert.is_true(box_called)
+    end)
+
   end)
-
-
-
 
 
 

--- a/src/terminal/draw/init.lua
+++ b/src/terminal/draw/init.lua
@@ -93,6 +93,8 @@ M.box_fmt = utils.make_lookup("box-format", {
   -- fmt.pre = fmt.pre .. " "
   -- fmt.post = " " .. fmt.post
   copy = function(default)
+    -- TODO: also add 'copy' such that it becomes a method of the copied format, and can be used to create variations of variations (preferably using a metatable to avoid copying the function every time)
+    -- then chack all uses of this 'copy' function to replace them with method calls (including the above usage example).
     return {
       t = default.t,
       b = default.b,

--- a/src/terminal/ui/panel/init.lua
+++ b/src/terminal/ui/panel/init.lua
@@ -52,6 +52,8 @@ local utils = require("terminal.utils")
 local draw = require("terminal.draw")
 local text = require("terminal.text")
 
+
+
 local Panel = utils.class()
 
 
@@ -255,14 +257,12 @@ function Panel:_calculate_inner_area()
       height = height - 1
     end
 
-    if format.l ~= "" then
-      col = col + 1
-      width = width - 1
-    end
+    local wl = text.width.utf8swidth(format.l or "")
+    col = col + wl
+    width = width - wl
 
-    if format.r ~= "" then
-      width = width - 1
-    end
+    local wr = text.width.utf8swidth(format.r or "")
+    width = width - wr
 
     if format.b ~= "" then
       height = height - 1

--- a/src/terminal/ui/panel/init.lua
+++ b/src/terminal/ui/panel/init.lua
@@ -54,6 +54,22 @@ local text = require("terminal.text")
 
 
 
+-- Returns the number of rows consumed by top/bottom borders (0 or 1 each).
+local function border_h_overhead(format)
+  return (format.t ~= "" and 1 or 0)
+       + (format.b ~= "" and 1 or 0)
+end
+
+
+
+-- Returns the number of columns consumed by left/right borders.
+local function border_w_overhead(format)
+  return text.width.utf8swidth(format.l or "")
+       + text.width.utf8swidth(format.r or "")
+end
+
+
+
 local Panel = utils.class()
 
 
@@ -97,7 +113,7 @@ local DEFAULT_MAX_SIZE = math.huge
 -- @tparam[opt=math.huge] number opts.max_width Maximum width constraint.
 -- @tparam[opt=0.5] number opts.split_ratio Ratio for dividing child panels (0.0 to 1.0).
 -- @tparam[opt=true] boolean opts.visible Whether the panel is visible (true) or hidden (false).
--- @tparam[opt] table opts.border Border configuration for content panels, with the following properties:
+-- @tparam[opt] table opts.border Border configuration, with the following properties:
 -- @tparam table opts.border.format The box format table (see `terminal.draw.box_fmt`).
 -- @tparam[opt] table opts.border.attr Table of attributes for the border, eg. `{ fg = "red", bg = "blue" }`.
 -- @tparam[opt] string opts.border.title Optional title to display in the border.
@@ -131,13 +147,6 @@ function Panel:init(opts)
     self.clear_content = opts.clear_content ~= false
     self.orientation = nil
     self.children = nil
-
-    -- Border configuration for content panels
-    self.border = opts.border
-    if self.border then
-      assert(type(self.border) == "table", "border must be a table")
-      assert(self.border.format, "border.format is required when border is specified")
-    end
   else
     -- Divided panel
     assert(#opts.children == 2, "Divided panel must have exactly 2 children")
@@ -150,6 +159,13 @@ function Panel:init(opts)
     self.children = opts.children
     self.split_ratio = opts.split_ratio or 0.5
     assert(self.split_ratio >= 0.0 and self.split_ratio <= 1.0, "Split ratio must be between 0.0 and 1.0")
+  end
+
+  -- Border configuration
+  self.border = opts.border
+  if self.border then
+    assert(type(self.border) == "table", "border must be a table")
+    assert(self.border.format, "border.format is required when border is specified")
   end
 
   -- Size constraints (private)
@@ -292,15 +308,15 @@ function Panel:_calculate_children_layout()
     local child2_width
     if child1:visible() then
       if child2:visible() then  -- both children are visible
-        child1_width = math.floor(self.width * self.split_ratio)
-        child2_width = self.width - child1_width
+        child1_width = math.floor(self.inner_width * self.split_ratio)
+        child2_width = self.inner_width - child1_width
       else  -- only child1 is visible
-        child1_width = self.width
+        child1_width = self.inner_width
         child2_width = 0
       end
     else  -- only child2 is visible
       child1_width = 0
-      child2_width = self.width
+      child2_width = self.inner_width
     end
 
     -- Get size constraints
@@ -312,26 +328,26 @@ function Panel:_calculate_children_layout()
     -- Apply maximum width constraints
     if child1_width > child1_max_width then
       child1_width = child1_max_width
-      child2_width = self.width - child1_width
+      child2_width = self.inner_width - child1_width
     end
     if child2_width > child2_max_width then
       child2_width = child2_max_width
-      child1_width = self.width - child2_width
+      child1_width = self.inner_width - child2_width
     end
 
     -- Ensure minimum widths
     if child1_width < child1_min_width then
       child1_width = child1_min_width
-      child2_width = self.width - child1_width
+      child2_width = self.inner_width - child1_width
     end
     if child2_width < child2_min_width then
       child2_width = child2_min_width
-      child1_width = self.width - child2_width
+      child1_width = self.inner_width - child2_width
     end
 
     -- Calculate child layouts
-    child1:calculate_layout(self.row, self.col, self.height, child1_width)
-    child2:calculate_layout(self.row, self.col + child1_width, self.height, child2_width)
+    child1:calculate_layout(self.inner_row, self.inner_col, self.inner_height, child1_width)
+    child2:calculate_layout(self.inner_row, self.inner_col + child1_width, self.inner_height, child2_width)
 
   else -- VERTICAL
     -- Vertical division: split height
@@ -340,15 +356,15 @@ function Panel:_calculate_children_layout()
 
     if child1:visible() then
       if child2:visible() then  -- both children are visible
-        child1_height = math.floor(self.height * self.split_ratio)
-        child2_height = self.height - child1_height
+        child1_height = math.floor(self.inner_height * self.split_ratio)
+        child2_height = self.inner_height - child1_height
       else  -- only child1 is visible
-        child1_height = self.height
+        child1_height = self.inner_height
         child2_height = 0
       end
     else  -- only child2 is visible
       child1_height = 0
-      child2_height = self.height
+      child2_height = self.inner_height
     end
 
     -- Get size constraints
@@ -360,26 +376,26 @@ function Panel:_calculate_children_layout()
     -- Apply maximum height constraints
     if child1_height > child1_max_height then
       child1_height = child1_max_height
-      child2_height = self.height - child1_height
+      child2_height = self.inner_height - child1_height
     end
     if child2_height > child2_max_height then
       child2_height = child2_max_height
-      child1_height = self.height - child2_height
+      child1_height = self.inner_height - child2_height
     end
 
     -- Ensure minimum heights
     if child1_height < child1_min_height then
       child1_height = child1_min_height
-      child2_height = self.height - child1_height
+      child2_height = self.inner_height - child1_height
     end
     if child2_height < child2_min_height then
       child2_height = child2_min_height
-      child1_height = self.height - child2_height
+      child1_height = self.inner_height - child2_height
     end
 
     -- Calculate child layouts
-    child1:calculate_layout(self.row, self.col, child1_height, self.width)
-    child2:calculate_layout(self.row + child1_height, self.col, child2_height, self.width)
+    child1:calculate_layout(self.inner_row, self.inner_col, child1_height, self.inner_width)
+    child2:calculate_layout(self.inner_row + child1_height, self.inner_col, child2_height, self.inner_width)
   end
 end
 
@@ -430,9 +446,9 @@ function Panel:render()
     return  -- Skip rendering hidden panels
   end
 
+  self:draw_border()
+
   if self.content then
-    -- Render content panel with optional border
-    self:draw_border()
     if self.clear_content then
       self:clear()
     end
@@ -484,6 +500,10 @@ function Panel:get_min_height()
     derived_min_height = self.children[1]:get_min_height() + self.children[2]:get_min_height()
   end
 
+  if self.border then
+    derived_min_height = derived_min_height + border_h_overhead(self.border.format)
+  end
+
   return math.max(self._min_height, derived_min_height)
 end
 
@@ -505,6 +525,10 @@ function Panel:get_min_width()
   else -- VERTICAL
     -- Width constraints are the minimum of both children
     derived_min_width = math.max(self.children[1]:get_min_width(), self.children[2]:get_min_width())
+  end
+
+  if self.border then
+    derived_min_width = derived_min_width + border_w_overhead(self.border.format)
   end
 
   return math.max(self._min_width, derived_min_width)
@@ -530,6 +554,10 @@ function Panel:get_max_height()
     derived_max_height = self.children[1]:get_max_height() + self.children[2]:get_max_height()
   end
 
+  if self.border then
+    derived_max_height = derived_max_height + border_h_overhead(self.border.format)
+  end
+
   return math.min(self._max_height, derived_max_height)
 end
 
@@ -551,6 +579,10 @@ function Panel:get_max_width()
   else -- VERTICAL
     -- Width constraints are the minimum of both children
     derived_max_width = math.min(self.children[1]:get_max_width(), self.children[2]:get_max_width())
+  end
+
+  if self.border then
+    derived_max_width = derived_max_width + border_w_overhead(self.border.format)
   end
 
   return math.min(self._max_width, derived_max_width)


### PR DESCRIPTION
previously only content panel could have borders. But sometimes a user-visible panel consists of multiple underlying panels (presented to the user as one). An example is a dialog box, where the upper part is a text panel, the lower a button bar, but the whole is a single panel, with a single border to the user.

A bug that surfaced during implementation is also fixed (border width wasn't properly taken into account)