### PR TITLE
refactor(box_fmt): add metatable with copy method

### DIFF
--- a/examples/panel.lua
+++ b/examples/panel.lua
@@ -175,18 +175,18 @@ local function run_example_4()
   terminal.cursor.position.set(1, 1)
 
   -- create custom formats to connect the panel borders visually
-  local fmt_top_left = terminal.draw.box_fmt.copy(terminal.draw.box_fmt.single)
+  local fmt_top_left = terminal.draw.box_fmt.single:copy()
   fmt_top_left.tr = "┬" -- connect to the right panel top left corner
   fmt_top_left.b = ""   -- do not draw the bottom bar (use the lower panels top bar)
   fmt_top_left.bl = fmt_top_left.l  -- no edge, continue vertical line
   fmt_top_left.br = fmt_top_left.l  -- no edge, continue vertical line
 
-  local fmt_bottom_left = terminal.draw.box_fmt.copy(terminal.draw.box_fmt.single)
+  local fmt_bottom_left = terminal.draw.box_fmt.single:copy()
   fmt_bottom_left.tl = "├"  -- connect to the top panel bottom left corner
   fmt_bottom_left.tr = "┤"  -- connect to the top panel bottom right corner
   fmt_bottom_left.br = "┴"  -- connect to the right panel bottom left corner
 
-  local fmt_right = terminal.draw.box_fmt.copy(terminal.draw.box_fmt.single)
+  local fmt_right = terminal.draw.box_fmt.single:copy()
   fmt_right.l = ""    -- do not draw the left border (use the left panels right border)
   fmt_right.tl = fmt_right.t -- no edge, continue horizontal line
   fmt_right.bl = fmt_right.b -- no edge, continue horizontal line

--- a/spec/13-draw_spec.lua
+++ b/spec/13-draw_spec.lua
@@ -4,10 +4,12 @@ local helpers = require "spec.helpers"
 describe("terminal.draw", function()
 
   local line
+  local draw
 
   setup(function()
     helpers.load()
     line = require("terminal.draw.line")
+    draw = require("terminal.draw")
   end)
 
 
@@ -210,6 +212,58 @@ describe("terminal.draw", function()
       local expected = line.title_seq(10, nil)
       line.title(10, nil)
       assert.are.equal(expected, helpers.get_output())
+    end)
+
+  end)
+
+
+  describe("box_fmt:copy()", function()
+
+    it("copies all fields from the source format", function()
+      local src = draw.box_fmt.single
+      local copy = src:copy()
+      assert.are.equal(src.t,    copy.t)
+      assert.are.equal(src.b,    copy.b)
+      assert.are.equal(src.l,    copy.l)
+      assert.are.equal(src.r,    copy.r)
+      assert.are.equal(src.tl,   copy.tl)
+      assert.are.equal(src.tr,   copy.tr)
+      assert.are.equal(src.bl,   copy.bl)
+      assert.are.equal(src.br,   copy.br)
+      assert.are.equal(src.pre,  copy.pre)
+      assert.are.equal(src.post, copy.post)
+    end)
+
+    it("returns a distinct table", function()
+      local copy = draw.box_fmt.single:copy()
+      assert.are_not.equal(draw.box_fmt.single, copy)
+    end)
+
+    it("modifications to the copy do not affect the source", function()
+      local copy = draw.box_fmt.single:copy()
+      copy.tl = "X"
+      assert.are_not.equal("X", draw.box_fmt.single.tl)
+    end)
+
+    it("the copy has a copy method (variations of variations)", function()
+      local copy = draw.box_fmt.single:copy()
+      assert.is_function(copy.copy)
+    end)
+
+    it("copy of a copy carries all fields", function()
+      local copy1 = draw.box_fmt.single:copy()
+      copy1.tl = "X"
+      local copy2 = copy1:copy()
+      assert.are.equal("X", copy2.tl)
+      assert.are.equal(draw.box_fmt.single.t, copy2.t)
+    end)
+
+    it("works on every predefined format", function()
+      for _, name in ipairs({ "single", "rounded", "single_top", "double", "double_top" }) do
+        local fmt = draw.box_fmt[name]
+        local copy = fmt:copy()
+        assert.is_function(copy.copy, name .. ":copy() should return a copyable table")
+      end
     end)
 
   end)

--- a/spec/20-panel_spec.lua
+++ b/spec/20-panel_spec.lua
@@ -763,7 +763,7 @@ describe("terminal.ui.panel", function()
 
     it("accounts for double-width border characters in inner area", function()
       local draw = require("terminal.draw")
-      local fmt = draw.box_fmt.copy(draw.box_fmt.single)
+      local fmt = draw.box_fmt.single:copy()
       fmt.l = "一"  -- U+4E00, display width 2
       fmt.r = "一"
 

--- a/src/terminal/draw/init.lua
+++ b/src/terminal/draw/init.lua
@@ -16,100 +16,99 @@ local text = require "terminal.text"
 
 
 
---- Table with pre-defined box formats.
--- @table box_fmt
--- @field single Single line box format
--- @field single_top Single line box format with top border only
--- @field double Double line box format
--- @field double_top Double line box format with top border only
--- @field copy Function to copy a box format, see `box_fmt.copy` for details
-M.box_fmt = utils.make_lookup("box-format", {
-  single = {
-    t = "─",
-    b = "─",
-    l = "│",
-    r = "│",
-    tl = "┌",
-    tr = "┐",
-    bl = "└",
-    br = "┘",
-    pre = "┤",
-    post = "├",
-  },
-  rounded = {
-    t = "─",
-    b = "─",
-    l = "│",
-    r = "│",
-    tl = "╭",
-    tr = "╮",
-    bl = "╰",
-    br = "╯",
-    pre = "┤",
-    post = "├",
-  },
-  single_top = {
-    t = "─",
-    b = "",
-    l = "",
-    r = "",
-    tl = "",
-    tr = "",
-    bl = "",
-    br = "",
-    pre = "┤",
-    post = "├",
-  },
-  double = {
-    t = "═",
-    b = "═",
-    l = "║",
-    r = "║",
-    tl = "╔",
-    tr = "╗",
-    bl = "╚",
-    br = "╝",
-    pre = "╡",
-    post = "╞",
-  },
-  double_top = {
-    t = "═",
-    b = "",
-    l = "",
-    r = "",
-    tl = "",
-    tr = "",
-    bl = "",
-    br = "",
-    pre = "╡",
-    post = "╞",
-  },
-  --- Copy a box format.
-  -- @function box_fmt.copy
-  -- @tparam table default the default format to copy
-  -- @treturn table a copy of the default format provided
+do
+  local box_fmt_meta = {}
+  box_fmt_meta.__index = {
+    copy = function(self)
+      return setmetatable({
+        t = self.t,
+        b = self.b,
+        l = self.l,
+        r = self.r,
+        tl = self.tl,
+        tr = self.tr,
+        bl = self.bl,
+        br = self.br,
+        pre = self.pre,
+        post = self.post,
+      }, box_fmt_meta)
+    end,
+  }
+
+  --- Table with pre-defined box formats.
+  -- They also have a `copy` method to quickly copy and customize a format.
+  -- @table box_fmt
+  -- @field single Single line box format
+  -- @field single_top Single line box format with top border only
+  -- @field double Double line box format
+  -- @field double_top Double line box format with top border only
   -- @usage -- create new format with spaces around the title
-  -- local fmt = t.box_fmt.copy(t.box_fmt.single)
+  -- local fmt = t.box_fmt.single:copy()
   -- fmt.pre = fmt.pre .. " "
   -- fmt.post = " " .. fmt.post
-  copy = function(default)
-    -- TODO: also add 'copy' such that it becomes a method of the copied format, and can be used to create variations of variations (preferably using a metatable to avoid copying the function every time)
-    -- then chack all uses of this 'copy' function to replace them with method calls (including the above usage example).
-    return {
-      t = default.t,
-      b = default.b,
-      l = default.l,
-      r = default.r,
-      tl = default.tl,
-      tr = default.tr,
-      bl = default.bl,
-      br = default.br,
-      pre = default.pre,
-      post = default.post,
-    }
-  end,
-})
-
+  M.box_fmt = utils.make_lookup("box-format", {
+    single = setmetatable({
+      t = "─",
+      b = "─",
+      l = "│",
+      r = "│",
+      tl = "┌",
+      tr = "┐",
+      bl = "└",
+      br = "┘",
+      pre = "┤",
+      post = "├",
+    }, box_fmt_meta),
+    rounded = setmetatable({
+      t = "─",
+      b = "─",
+      l = "│",
+      r = "│",
+      tl = "╭",
+      tr = "╮",
+      bl = "╰",
+      br = "╯",
+      pre = "┤",
+      post = "├",
+    }, box_fmt_meta),
+    single_top = setmetatable({
+      t = "─",
+      b = "",
+      l = "",
+      r = "",
+      tl = "",
+      tr = "",
+      bl = "",
+      br = "",
+      pre = "┤",
+      post = "├",
+    }, box_fmt_meta),
+    double = setmetatable({
+      t = "═",
+      b = "═",
+      l = "║",
+      r = "║",
+      tl = "╔",
+      tr = "╗",
+      bl = "╚",
+      br = "╝",
+      pre = "╡",
+      post = "╞",
+    }, box_fmt_meta),
+    double_top = setmetatable({
+      t = "═",
+      b = "",
+      l = "",
+      r = "",
+      tl = "",
+      tr = "",
+      bl = "",
+      br = "",
+      pre = "╡",
+      post = "╞",
+    }, box_fmt_meta),
+  })
+end
 
 
 --- Creates a sequence to draw a box, without writing it to the terminal.


### PR DESCRIPTION
Provides a nicer format than the previously separate copy method